### PR TITLE
Nonblocking

### DIFF
--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -99,7 +99,8 @@ class AuditMiddleware(object):
         event = self._cadf_audit.create_event(request, response)
 
         if event:
-            self._notifier.notify(request.context, event.as_dict())
+            context = {}    # currently empty
+            self._notifier.notify(context, event.as_dict())
 
     @webob.dec.wsgify
     def __call__(self, req):

--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -48,6 +48,10 @@ _AUDIT_OPTS = [
                help='A URL representing messaging driver to use for '
                     'notification. If not specified, we fall back to the same '
                     'configuration used for RPC.'),
+    cfg.IntOpt('mem_queue_size',
+               help='Size of the in-memory queue that is used to buffer '
+                    'messages that have not yet been accepted by the '
+                    'transport'),
 ]
 CONF = cfg.CONF
 CONF.register_opts(_AUDIT_OPTS, group=AUDIT_MIDDLEWARE_GROUP)

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -177,8 +177,6 @@ class OpenStackAuditMiddleware(object):
 
     def _create_crud_event(self, res_id, res_parent_id, res_spec, request,
                            response):
-        # singletons cannot have their own ID, so we take the parent's one
-        rid = res_parent_id if res_spec.singleton else res_id
 
         event = self._create_event(res_spec, res_id, res_parent_id,
                                    request, response, None)

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -16,7 +16,6 @@ import uuid
 
 import yaml
 from oslo_log import log as logging
-from oslo_serialization import jsonutils
 from pycadf import cadftaxonomy as taxonomy, endpoint
 from pycadf import cadftype
 from pycadf import eventfactory
@@ -58,8 +57,8 @@ class OpenStackAuditMiddleware(object):
             conf = yaml.safe_load(open(cfg_file, 'r'))
 
             self._service_type = conf['service_type']
-            self._service_name = conf.get('service_name')
-            self._service_id = None
+            self._service_name = conf.get('service_name', self._service_type)
+            self._service_id = self._build_service_id(self._service_name)
             self._prefix_template = conf['prefix']
             # default_target_endpoint_type = conf.get('target_endpoint_type')
             # self._service_endpoints = conf.get('service_endpoints', {})
@@ -342,40 +341,18 @@ class OpenStackAuditMiddleware(object):
     def _build_target_service_resource(self, res_spec, req):
         """Build target resource."""
         target_type_uri = 'service/' + res_spec.type_uri
-        id, name = self.get_service_info(req)
         target = resource.Resource(typeURI=target_type_uri,
-                                   id=id, name=name)
+                                   id=self._service_id,
+                                   name=self._service_name)
         target.add_address(endpoint.Endpoint(req.path_url))
 
         return target
 
-    def get_service_info(self, req):
-        if self._service_id is None:
-            catalog = {}
-            try:
-                catalog = jsonutils.loads(
-                    req.environ['HTTP_X_SERVICE_CATALOG'])
-            except KeyError:
-                self._log.warning(
-                    'Unable to discover target information because '
-                    'service catalog is missing. Either the incoming '
-                    'request does not contain an auth token or auth '
-                    'token does not contain a service catalog. For '
-                    'the latter, please make sure the '
-                    '"include_service_catalog" property in '
-                    'auth_token middleware is set to "True"')
-                name = (self._service_name or self._service_type)
-                md5_hash = hashlib.md5(name.encode('utf-8'))  # nosec
-                ns = uuid.UUID(md5_hash.hexdigest())
-                self._service_id = str(uuid.uuid5(ns, str(uuid.uuid4())))
-
-            for endp in catalog:
-                if endp['type'] == self._service_type:
-                    self._service_id = endp['id']
-                    self._service_name = endp['name']
-                    break
-
-        return self._service_id, self._service_name
+    @staticmethod
+    def _build_service_id(name):
+        md5_hash = hashlib.md5(name.encode('utf-8'))  # nosec
+        ns = uuid.UUID(md5_hash.hexdigest())
+        return str(uuid.uuid5(ns, str(uuid.uuid4())))
 
     def _strip_url_prefix(self, request):
         """ Removes the prefix from the URL paths, e.g. '/V2/{project_id}/'

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -16,7 +16,6 @@ import yaml
 from oslo_log import log as logging
 from pycadf import cadftaxonomy as taxonomy, endpoint
 from pycadf import cadftype
-from pycadf import credential
 from pycadf import eventfactory
 from pycadf import host
 from pycadf import reason

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -320,7 +320,7 @@ class OpenStackAuditMiddleware(object):
         target = None
         if res_id:
             rtype = None
-            if action == taxonomy.ACTION_LIST or res_spec.singleton:
+            if action.startswith(taxonomy.ACTION_LIST) or res_spec.singleton:
                 rtype = res_spec.type_uri
             else:
                 rtype = res_spec.el_type_uri

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -48,13 +48,6 @@ class ClientResource(resource.Resource):
             self.project_id = project_id
 
 
-class KeystoneCredential(credential.Credential):
-    def __init__(self, identity_status=None, **kwargs):
-        super(KeystoneCredential, self).__init__(**kwargs)
-        if identity_status is not None:
-            self.identity_status = identity_status
-
-
 class OpenStackAuditMiddleware(object):
     def __init__(self, cfg_file, log=logging.getLogger(__name__)):
         """Configure to recognize and map known api paths."""
@@ -300,10 +293,6 @@ class OpenStackAuditMiddleware(object):
             name=request.environ.get('HTTP_X_USER_NAME', taxonomy.UNKNOWN),
             host=host.Host(address=request.client_addr,
                            agent=request.user_agent),
-            credential=KeystoneCredential(
-                token=request.environ.get('HTTP_X_AUTH_TOKEN', ''),
-                identity_status=request.environ.get('HTTP_X_IDENTITY_STATUS',
-                                                    taxonomy.UNKNOWN)),
             project_id=project_or_domain_id)
 
         action_result = None

--- a/auditmiddleware/_notifier.py
+++ b/auditmiddleware/_notifier.py
@@ -41,6 +41,7 @@ class _MessagingNotifier(Thread):
         self._queue = queue.Queue(mem_queue_size)
 
     def __del__(self):
+        self._log.info("shutting down auditmiddleware notifications thread")
         self.flush_to_log()
 
     def notify(self, context, payload):

--- a/auditmiddleware/_notifier.py
+++ b/auditmiddleware/_notifier.py
@@ -13,7 +13,7 @@
 import os
 import random
 import sys
-from Queue import Queue
+import Queue as queue
 
 import time
 
@@ -42,7 +42,7 @@ class _MessagingNotifier(object):
         self._notifier = notifier
         self._seq_errors = 0
         self._wait_until = time.time()
-        self._queue = Queue(10000)
+        self._queue = queue.Queue(10000)
 
     def __del__(self):
         if not self._queue.empty():
@@ -68,7 +68,7 @@ class _MessagingNotifier(object):
     def enqueue_notification(self, payload, context):
         try:
             self._queue.put_nowait((payload, context))
-        except Queue.Full:
+        except queue.Full:
             self._log.warning("Audit events could not be delivered ("
                               "buffer full). Payload follows ...")
             self.log_event(context, payload)
@@ -86,7 +86,7 @@ class _MessagingNotifier(object):
                 payload, context = self._queue.get_nowait()
                 self._notifier.info(context, "audit.cadf", payload)
                 self._seq_errors = 0
-        except Queue.Empty:
+        except queue.Empty:
             # ignore
             pass
         except Exception as e:
@@ -95,7 +95,7 @@ class _MessagingNotifier(object):
                 while True:
                     self.log_event(context, payload)
                     payload, context = self._queue.get_nowait()
-            except Queue.Empty:
+            except queue.Empty:
                 pass
 
 

--- a/auditmiddleware/_notifier.py
+++ b/auditmiddleware/_notifier.py
@@ -40,10 +40,6 @@ class _MessagingNotifier(Thread):
         self._notifier = notifier
         self._queue = queue.Queue(mem_queue_size)
 
-    def __del__(self):
-        self._log.info("shutting down auditmiddleware notifications thread")
-        self.flush_to_log()
-
     def notify(self, context, payload):
         self.enqueue_notification(payload, context)
 

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -24,6 +24,7 @@ JSON = 'application/json'
 
 audit_map_content_nova = """
 service_type: 'compute'
+service_name: 'nova'
 prefix: '/v2/{project_id}'
 
 resources:
@@ -69,7 +70,6 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
 
         # service_name needs to be redefined by subclass
         self.service_name = None
-        self.service_id = None
         self.project_id = str(uuid.uuid4().hex)
         self.user_id = str(uuid.uuid4().hex)
         self.username = "test user " + str(user_counter)
@@ -103,12 +103,9 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
                                                "publicURL":
                                                "http://public_host:8774",
                                                "internalURL":
-                                               "http://internal_host:8774",
-                                               "id":
-                                               "16f7be69f0a44a9e825fbe22a5405d7b"}],
+                                               "http://internal_host:8774"}],
                                 "type": "compute",
-                                "name": "nova",
-                                "id": "16f7be69f0a44a9e825fbe22a5405d7b"}]''',
+                                "name": "nova"}]''',
                        }
         if req_type:
             env_headers['REQUEST_METHOD'] = req_type
@@ -166,8 +163,8 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
         self.assertEqual(event['outcome'], outcome)
         self.assertEqual(event['eventType'], 'activity')
         self.assertEqual(event['target'].get('name'), target_name)
-        self.assertEqual(event['target'].get('id'), target_id or
-                         self.service_id)
+        if target_id:  # only check what is known
+            self.assertEqual(event['target'].get('id'), target_id)
         self.assertEqual(event['target']['typeURI'], target_type_uri)
         self.assertEqual(event['initiator']['id'], self.user_id)
         self.assertEqual(event['initiator'].get('name'), self.username)

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -81,7 +81,7 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
             return cb(req)
 
         kwargs.setdefault('audit_map_file', self.audit_map)
-        kwargs.setdefault('service_name', 'pycadf')
+        kwargs.setdefault('service_name', 'nova')
 
         return auditmiddleware.AuditMiddleware(_do_cb, **kwargs)
 

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -43,6 +43,8 @@ resources:
                   'GET:*': 'read/metadata/*'
                   'PUT:*': 'update/metadata/*'
                   'DELETE:*': 'delete/metadata/*'
+            volume-attachments:
+                api_name: os-volume_attachments
             tags:
     os-services:
         # all default

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -161,11 +161,6 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
                          '192.168.0.1')
         self.assertEqual(event['initiator']['typeURI'],
                          'service/security/account/user')
-        # TODO: review current behaviour (why have an obfuscated token
-        # instead of a prefix)
-        self.assertNotEqual(event['initiator']['credential']['token'], 'token')
-        self.assertEqual(event['initiator']['credential']['identity_status'],
-                         'Confirmed')
         # these fields are only available for finished requests
         if outcome == 'pending':
             self.assertNotIn('reason', event)

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -21,7 +21,6 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
     def setUp(self):
         super(AuditApiLogicTest, self).setUp()
         self.service_name = 'nova'
-        self.service_id = '16f7be69f0a44a9e825fbe22a5405d7b'
 
     def test_get_list(self):
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -29,7 +28,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_LIST,
-                         "service/compute/servers", self.service_id,
+                         "service/compute/servers", None,
                          self.service_name)
 
     def test_get_read(self):
@@ -205,7 +204,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, "update/disable",
-                         "service/compute/os-services", self.service_id,
+                         "service/compute/os-services", None,
                          self.service_name)
 
     def test_post_action_missing_payload(self):
@@ -263,7 +262,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, "read/list/details",
-                         "service/compute/servers", self.service_id,
+                         "service/compute/servers", None,
                          self.service_name)
 
         # TODO: fix and enable for Swift

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -21,6 +21,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
     def setUp(self):
         super(AuditApiLogicTest, self).setUp()
         self.service_name = 'nova'
+        self.service_id = '16f7be69f0a44a9e825fbe22a5405d7b'
 
     def test_get_list(self):
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -28,7 +29,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_LIST,
-                         "service/compute/servers")
+                         "service/compute/servers", self.service_id,
+                         self.service_name)
 
     def test_get_read(self):
         rid = str(uuid.uuid4().hex)
@@ -203,7 +205,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, "update/disable",
-                         "service/compute/os-services")
+                         "service/compute/os-services", self.service_id,
+                         self.service_name)
 
     def test_post_action_missing_payload(self):
         rid = str(uuid.uuid4().hex)
@@ -260,7 +263,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, "read/list/details",
-                         "service/compute/servers")
+                         "service/compute/servers", self.service_id,
+                         self.service_name)
 
         # TODO: fix and enable for Swift
         # def test_no_auth_token(self):

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -31,6 +31,18 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "service/compute/servers", None,
                          self.service_name)
 
+    def test_get_list_child(self):
+        rid = str(uuid.uuid4().hex)
+        # this property is modelled as custom action
+        key = "os-volume_attachments"
+        url = self.build_url('servers', prefix='/v2/' + self.project_id,
+                             res_id=rid, child_res=key)
+        request, response = self.build_api_call('GET', url)
+        event = self.build_event(request, response)
+
+        self.check_event(request, response, event, taxonomy.ACTION_LIST,
+                         "compute/server/volume-attachments", rid)
+
     def test_get_read(self):
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,

--- a/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
+++ b/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
@@ -11,6 +11,7 @@
 # under the License.
 
 import mock
+import time
 from oslo_messaging import MessagingException
 
 from auditmiddleware.tests.unit import base
@@ -35,6 +36,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
             app.get(path, extra_environ=self.get_environ_header())
             # audit middleware conf has 'log' make sure that driver is invoked
             # and not the one specified in DEFAULT section
+            time.sleep(1)
             self.assertTrue(driver.called)
 
     def test_conf_middleware_log_and_default_as_messaging(self):
@@ -47,6 +49,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
             app.get(path, extra_environ=self.get_environ_header())
             # audit middleware conf has 'log' make sure that driver is invoked
             # and not the one specified in DEFAULT section
+            time.sleep(1)
             self.assertTrue(driver.called)
 
     def test_conf_middleware_log_and_oslo_msg_as_messaging(self):
@@ -62,6 +65,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
             app.get(path, extra_environ=self.get_environ_header())
             # audit middleware conf has 'log' make sure that driver is invoked
             # and not the one specified in oslo_messaging_notifications section
+            time.sleep(1)
             self.assertTrue(driver.called)
 
     def test_conf_middleware_messaging_and_oslo_msg_as_log(self):
@@ -76,6 +80,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
             # and not the one specified in oslo_messaging_notifications section
             path = '/v2/' + self.project_id + '/servers'
             app.get(path, extra_environ=self.get_environ_header())
+            time.sleep(1)
             self.assertTrue(driver.called)
 
     def test_with_no_middleware_notification_conf(self):
@@ -91,6 +96,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
             # invoked from oslo_messaging_notifications section.
             path = '/v2/' + self.project_id + '/servers'
             app.get(path, extra_environ=self.get_environ_header())
+            time.sleep(1)
             self.assertTrue(driver.called)
 
     @mock.patch('oslo_messaging.get_notification_transport')
@@ -101,6 +107,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
                         group='audit_middleware_notifications')
 
         self.create_simple_middleware()
+        time.sleep(1)
         self.assertTrue(m.called)
         # make sure first call kwarg 'url' is same as provided transport_url
         self.assertEqual(transport_url, m.call_args_list[0][1]['url'])

--- a/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
+++ b/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
@@ -14,7 +14,6 @@ import mock
 from oslo_messaging import MessagingException
 
 from auditmiddleware.tests.unit import base
-from oslo_messaging._drivers.impl_rabbit import Connection
 
 
 class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -23,7 +23,7 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         return self.audit_map_file_fixture
 
     def test_get_list(self):
-        url = self.build_url('servers', prefix='/v2/' + self.project_id)
+        url = self.build_url('servers', prefix='/compute/v2.1')
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
 

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -17,7 +17,6 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
             self.audit_map_file_fixture)
 
         self.service_name = 'nova'
-        self.service_id = '16f7be69f0a44a9e825fbe22a5405d7b'
 
     @property
     def audit_map(self):
@@ -30,4 +29,4 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
         self.check_event(request, response, event, taxonomy.ACTION_LIST,
                          "service/compute/servers",
-                         self.service_id, self.service_name)
+                         None, self.service_name)

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -17,6 +17,7 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
             self.audit_map_file_fixture)
 
         self.service_name = 'nova'
+        self.service_id = '16f7be69f0a44a9e825fbe22a5405d7b'
 
     @property
     def audit_map(self):
@@ -28,4 +29,5 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_LIST,
-                         "service/compute/servers")
+                         "service/compute/servers",
+                         self.service_id, self.service_name)

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -12,8 +12,7 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         super(NovaAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/nova_audit_map.yaml"
-        if not os.path.isfile(self.audit_map_file_fixture):
-            self.audit_map_file_fixture = '../../../etc/nova_audit_map.yaml'
+
         self.audit_map_file_fixture = os.path.realpath(
             self.audit_map_file_fixture)
 

--- a/etc/nova_audit_map.yaml
+++ b/etc/nova_audit_map.yaml
@@ -3,6 +3,7 @@ service_name: 'nova'
 prefix: '/compute/v2.1'
 
 resources:
+    # NOTE: proxy-kind API are ignored
     agents:
         api_name: os-agents
         custom_id: 'agent_id'
@@ -18,10 +19,12 @@ resources:
         singleton: true
         custom_actions:
             detail: read/list/details
+    # cells: omitted
     consoles:
         custom_id: 'console_id'
     flavors:
         custom_actions:
+            detail: read/list/details
             addTenantAccess: allow/tenant-access
             removeTenantAccess: deny/tenant-access
 
@@ -39,6 +42,8 @@ resources:
     migrations:
     hypervisors:
         api_name: os-hypervisors
+        custom_actions:
+            detail: read/list/details
         children:
             uptime:
                 singleton: true

--- a/etc/nova_audit_map.yaml
+++ b/etc/nova_audit_map.yaml
@@ -1,6 +1,6 @@
 service_type: 'compute'
 service_name: 'nova'
-prefix: '/v2/{project_id}'
+prefix: '/compute/v2.1'
 
 resources:
     agents:
@@ -128,7 +128,7 @@ resources:
                 singleton: true
             tags:
             volume-attachments:
-                api_name: os-volument_attachments
+                api_name: os-volumen_attachments
     server-groups:
         api_name: os-server-groups
     services:
@@ -140,5 +140,4 @@ resources:
             force-down: update
     usage:
         api_name: os-simple-tenant-usage
-
 

--- a/etc/nova_audit_map.yaml
+++ b/etc/nova_audit_map.yaml
@@ -133,7 +133,7 @@ resources:
                 singleton: true
             tags:
             volume-attachments:
-                api_name: os-volumen_attachments
+                api_name: os-volume_attachments
     server-groups:
         api_name: os-server-groups
     services:


### PR DESCRIPTION
Perform sending of events to RabbitMQ in a background thread. Background thread and application communicate via a Python queue object that is in-memory. Usually that queue is empty. It will only fill up when the background thread starves or RabbitMQ is down / lagging.
 
The queue size is limited. In case of an overflow, all queue contents are written to the log. The contents of the queue will be lost when the application is stopped.

solves #4 