### PR TITLE
Create events also for undeclared resources

### DIFF
--- a/.idea/inspectionProfiles/Project_Default.xml
+++ b/.idea/inspectionProfiles/Project_Default.xml
@@ -1,0 +1,32 @@
+<component name="InspectionProjectProfileManager">
+  <profile version="1.0">
+    <option name="myName" value="Project Default" />
+    <inspection_tool class="PyCompatibilityInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ourVersions">
+        <value>
+          <list size="3">
+            <item index="0" class="java.lang.String" itemvalue="2.7" />
+            <item index="1" class="java.lang.String" itemvalue="3.6" />
+            <item index="2" class="java.lang.String" itemvalue="3.7" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPackageRequirementsInspection" enabled="true" level="WARNING" enabled_by_default="true">
+      <option name="ignoredPackages">
+        <value>
+          <list size="1">
+            <item index="0" class="java.lang.String" itemvalue="oslo.vmware" />
+          </list>
+        </value>
+      </option>
+    </inspection_tool>
+    <inspection_tool class="PyPep8Inspection" enabled="true" level="WEAK WARNING" enabled_by_default="true">
+      <option name="ignoredErrors">
+        <list>
+          <option value="E129" />
+        </list>
+      </option>
+    </inspection_tool>
+  </profile>
+</component>

--- a/README.md
+++ b/README.md
@@ -256,6 +256,6 @@ In our example this looks like this:
 Undeclared Resources
 --------------------
 
-Resources that are not declared in the mapping file will be reported as _unknown_ in the operational logs.  Still the middleware tries to create events for them based on heuristics. They can be recognized by the `X` prefix in the resource name.
+Resources that are not declared in the mapping file will be reported as _unknown_ in the operational logs.  Still the middleware tries to create events for them based on heuristics. They can be recognized by the `X` suffix in the resource name.
 
 When those X-resources show up, the mapping file should be extended with an appropriate resource definition. The reason is that the heuristics to discover and map undeclared resources are not covering all kinds of requests. There are ambiguities. 

--- a/README.md
+++ b/README.md
@@ -236,7 +236,7 @@ The configuration option to record request payloads needs some special considera
 * `payloads`: controls which attributes of the request payload may not be attached to the event (e.g. because they contain very sensitive information)
    - `enabled`: set to `false` to disable payload recording for this resource entirely (default: `true`)
    - `exclude`: exclude these payload attributes from the payload attachment (black-list approach, default: `[]`)
-   - `include`: only include these payload attributes in the payload attachment(white-list approach, default: `all)
+   - `include`: only include these payload attributes in the payload attachment(white-list approach, default: all)
 
 In our example this looks like this:
 

--- a/README.md
+++ b/README.md
@@ -130,12 +130,12 @@ The following metrics and dimensions are supported
 | openstack_audit_messaging_overflows | Number of lost events due to message queue latency or downtime | |
 | openstack_audit_messaging_errors | Failed attempts to push to message queue, leading to events dumped into log files | |
 
-Customizing the CADF mapping rules
+Mapping Rules
 ==================================
 
-The CADF mapping rules are essentially a model of resources. Due to REST principles, this model implies how the HTTP API requests are formed.
+The creation of audit events is driven by so called _mapping rules_. The CADF mapping rules are essentially a model of resources. Using OpenStack API design patterns, this model implies how the HTTP API requests are formed.
 
-The path of the request specifies the resource that is the target of the request. It consists of a prefix and a resource path. The resource path is denoting the resource. The prefix is used for versioning and routing. Sometimes it is even used to specify the target project of an operation (e.g. in Cinder).
+The path of an HTTP request specifies the resource that is the target of the request. It consists of a prefix and a resource path. The resource path is denoting the resource. The prefix is used for versioning and routing. Sometimes it is even used to specify the target project of an operation (e.g. in Cinder).
 
 In the mapping file, the prefix is specified using a regular expression. In those cases where the prefix contains the target project id, the regular expression needs to capture the relevant part of the prefix using a _named_ match group called
 _project\_id_
@@ -252,3 +252,10 @@ In our example this looks like this:
           # filter lengthy fields with no real diagnostic value
           - description
           - links
+
+Undeclared Resources
+--------------------
+
+Resources that are not declared in the mapping file will be reported as _unknown_ in the operational logs.  Still the middleware tries to create events for them based on heuristics. They can be recognized by the `X` prefix in the resource name.
+
+When those X-resources show up, the mapping file should be extended with an appropriate resource definition. The reason is that the heuristics to discover and map undeclared resources are not covering all kinds of requests. There are ambiguities. 

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -471,14 +471,6 @@ class OpenStackAuditMiddleware(object):
             target=target)
         event.requestPath = request.path_qs
 
-        #
-        if key and request.method[0] == 'P' and self._payloads_enabled and \
-                res_spec.payloads['enabled']:
-            req_pl = request.json
-            # remove possible wrapper elements
-            req_pl = req_pl.get(res_spec.el_type_name, req_pl)
-            self._attach_payload(event, req_pl, res_spec)
-
         # TODO add reporter step again?
         # event.add_reporterstep(
         #    reporterstep.Reporterstep(

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -298,7 +298,8 @@ class OpenStackAuditMiddleware(object):
         res_name = token.replace('_', '-')
         if res_name.startswith('os-'):
             res_name = res_name[3:]
-        res_dict = {'X' + res_name: {'api_name': token}}
+        res_name = 'X' + res_name
+        res_dict = {'api_name': token}
         sub_res_spec, _ = self._build_res_spec(res_name,
                                                parent_type_uri,
                                                res_dict)

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -157,49 +157,51 @@ class OpenStackAuditMiddleware(object):
         result = {}
 
         for name, s in six.iteritems(res_dict):
-            if not s:
-                spec = {}
-            else:
-                spec = s
-
-            if parent_type_uri:
-                pfx = parent_type_uri
-            else:
-                pfx = self._service_type
-
-            rest_name = spec.get('api_name', name)
-            singleton = spec.get('singleton', False)
-            type_name = spec.get('type_name')
-            if not type_name:
-                type_name = rest_name.replace('-', '_')
-                if type_name.startswith('os_'):
-                    type_name = type_name[3:]
-            type_uri = spec.get('type_uri', pfx + "/" + name)
-            el_type_name = None
-            el_type_uri = None
-            childs_parent_type_uri = None
-            if not singleton:
-                el_type_name = spec.get('el_type_name', type_name[:-1])
-                el_type_uri = type_uri[:-1]
-                childs_parent_type_uri = el_type_uri
-            else:
-                childs_parent_type_uri = type_uri
-
-            res_spec = ResourceSpec(type_name, el_type_name,
-                                    type_uri, el_type_uri, singleton,
-                                    spec.get('custom_id', 'id'),
-                                    spec.get('custom_name', 'name'),
-                                    str_map(spec.get('custom_actions')),
-                                    str_map(spec.get('custom_attributes')),
-                                    self._build_audit_map(
-                                        spec.get('children', {}),
-                                        childs_parent_type_uri),
-                                    payloads_map(spec.get('payloads')))
+            res_spec, rest_name = self._build_res_spec(name, parent_type_uri,
+                                                       s)
 
             # ensure that cust
             result[rest_name] = res_spec
 
         return result
+
+    def _build_res_spec(self, name, parent_type_uri, spec):
+        if not spec:
+            spec = {}
+        else:
+            spec = spec
+        if parent_type_uri:
+            pfx = parent_type_uri
+        else:
+            pfx = self._service_type
+        rest_name = spec.get('api_name', name)
+        singleton = spec.get('singleton', False)
+        type_name = spec.get('type_name')
+        if not type_name:
+            type_name = rest_name.replace('-', '_')
+            if type_name.startswith('os_'):
+                type_name = type_name[3:]
+        type_uri = spec.get('type_uri', pfx + "/" + name)
+        el_type_name = None
+        el_type_uri = None
+        childs_parent_type_uri = None
+        if not singleton:
+            el_type_name = spec.get('el_type_name', type_name[:-1])
+            el_type_uri = type_uri[:-1]
+            childs_parent_type_uri = el_type_uri
+        else:
+            childs_parent_type_uri = type_uri
+        res_spec = ResourceSpec(type_name, el_type_name,
+                                type_uri, el_type_uri, singleton,
+                                spec.get('custom_id', 'id'),
+                                spec.get('custom_name', 'name'),
+                                str_map(spec.get('custom_actions')),
+                                str_map(spec.get('custom_attributes')),
+                                self._build_audit_map(
+                                    spec.get('children', {}),
+                                    childs_parent_type_uri),
+                                payloads_map(spec.get('payloads')))
+        return res_spec, rest_name
 
     def create_events(self, request, response=None):
         # drop the endpoint's path prefix
@@ -243,14 +245,13 @@ class OpenStackAuditMiddleware(object):
         # handle the current token
         if isinstance(res_spec, dict):
             # the node contains a dict => handle token as resource name
-            res_spec = res_spec.get(token)
-            if res_spec is None:
-                # no such name, ignore/filter the resource
-                self._log.debug("unknown resource: %s", token)
+            sub_res_spec = res_spec.get(token)
+            if sub_res_spec is None:
+                # create resource spec on demand
+                sub_res_spec = self.register_resource(None, token)
+                res_spec[token] = sub_res_spec
 
-                return None
-
-            return self._build_events(target_project, res_spec, None, None,
+            return self._build_events(target_project, sub_res_spec, None, None,
                                       request,
                                       response,
                                       path, next_pos)
@@ -275,11 +276,34 @@ class OpenStackAuditMiddleware(object):
                 return self._create_events(target_project, res_id,
                                            res_parent_id, res_spec, request,
                                            response, token)
+            else:
+                # create resource spec on demand
+                res_spec.children[token] = self.register_resource(
+                    res_spec.el_type_uri,
+                    token)
+
+                # repeat same call with res_spec now existing
+                return self._build_events(target_project, res_spec, res_id,
+                                          res_parent_id, request, response,
+                                          path, cursor)
 
         self._log.warning(
             "Unexpected continuation of resource path after segment %s: %s",
             token, request.path)
         return None
+
+    def register_resource(self, parent_type_uri, token):
+        self._log.warn("unknown resource: %s (created on demand)",
+                       token)
+        res_name = token.replace('_', '-')
+        if res_name.startswith('os-'):
+            res_name = res_name[3:]
+        res_dict = {'X' + res_name: {'api_name': token}}
+        sub_res_spec, _ = self._build_res_spec(res_name,
+                                               parent_type_uri,
+                                               res_dict)
+
+        return sub_res_spec
 
     def _create_events(self, target_project, res_id,
                        res_parent_id,

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -211,6 +211,7 @@ class OpenStackAuditMiddleware(object):
                            request.path)
             return None
 
+        # normalize url: remove trailing slash and .json suffix
         path = path[:-1] if path.endswith('/') else path
         path = path[:-5] if path.endswith('.json') else path
         return self._build_events(target_project, self._resource_specs,
@@ -293,6 +294,11 @@ class OpenStackAuditMiddleware(object):
         return None
 
     def register_resource(self, parent_type_uri, token):
+        """ Register an unknown resource to avoid missed events.
+        The resulting events are a bit raw but contain enough information
+        to understand what happened. This allows for incremental
+        improvement.
+        """
         self._log.warn("unknown resource: %s (created on demand)",
                        token)
         res_name = token.replace('_', '-')
@@ -327,6 +333,7 @@ class OpenStackAuditMiddleware(object):
                 if self._payloads_enabled and res_spec.payloads['enabled']:
                     req_pl = iter(request.json.get(res_spec.type_name))
 
+                # create one event per item
                 for subpayload in res_pl:
                     ev = self._create_event_from_payload(target_project,
                                                          res_spec,
@@ -337,6 +344,7 @@ class OpenStackAuditMiddleware(object):
                     pl = next(req_pl) if req_pl else None
                     if ev:
                         if pl:
+                            # attach payload if requested
                             self._attach_payload(ev, pl, res_spec)
                         events.append(ev)
 
@@ -355,7 +363,7 @@ class OpenStackAuditMiddleware(object):
                 if not event:
                     return []
 
-                # attach payload if configured
+                # attach payload if requested
                 if self._payloads_enabled and res_spec.payloads['enabled']:
                     req_pl = request.json
                     # remove possible wrapper elements

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -131,9 +131,13 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
         if event_list:
             ev = event_list[0]
             if record_payloads:
-                self.assertIn('attachments', ev, "payload attachment missing")
-                self.assertIn('payload',
-                              [x['name'] for x in ev['attachments']])
+                self.assertIn('attachments', ev,
+                              "attachments missing (and thus no payload att.)")
+                payload_attachment = [x['name'] for x in ev['attachments']]
+                self.assertIn('payload', payload_attachment,
+                              'payload attachment missing')
+                self.assertEquals(1, payload_attachment.count('payload'),
+                                  "too many payload attachments")
             else:
                 self.assertNotIn('payload',
                                  [x['name'] for x in ev.get('attachments',

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -470,7 +470,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_CREATE,
-                         "compute/yetunknown", rid, rname)
+                         "compute/Xyetunknown", rid, rname)
 
     def test_put_resource_undeclared(self):
         rid = str(uuid.uuid4().hex)
@@ -482,7 +482,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_UPDATE,
-                         "compute/yetunknown/uchild", rid2)
+                         "compute/Xyetunknown/Xuchild", rid2)
 
     def test_post_action_no_response(self):
         rid = str(uuid.uuid4().hex)

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -460,22 +460,29 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         self.check_event(request, response, event, taxonomy.ACTION_UPDATE +
                          "/unknown", "compute/server", rid)
 
-    def test_post_resource_filtered(self):
+    def test_post_resource_undeclared(self):
         rid = str(uuid.uuid4().hex)
-        url = self.build_url('servers', prefix='/v2/' + self.project_id,
-                             suffix="unknown_action", res_id=rid,
-                             child_res_id="unknown")
-        request, response = self.build_api_call('POST', url, req_json={})
+        rname = "myname"
+        url = self.build_url('yetunknowns', prefix='/v2/' + self.project_id)
+        request, response = self.build_api_call('POST', url,
+                                                resp_json={'yetunknown': {
+                                                    'id': rid, 'name': rname}})
         event = self.build_event(request, response)
 
-        self.assertIsNone(event, "unknown child resources should be ignored")
+        self.check_event(request, response, event, taxonomy.ACTION_CREATE,
+                         "compute/yetunknown", rid, rname)
 
-    def test_put_resource_filtered(self):
-        url = self.build_url('unknown', prefix='/v2/' + self.project_id)
+    def test_put_resource_undeclared(self):
+        rid = str(uuid.uuid4().hex)
+        rid2 = str(uuid.uuid4().hex)
+        url = self.build_url('yetunknowns', prefix='/v2/' + self.project_id,
+                             res_id=rid, child_res="uchilds",
+                             child_res_id=rid2)
         request, response = self.build_api_call('PUT', url, req_json={})
         event = self.build_event(request, response)
 
-        self.assertIsNone(event, "unknown resources should be ignored")
+        self.check_event(request, response, event, taxonomy.ACTION_UPDATE,
+                         "compute/yetunknown/uchild", rid2)
 
     def test_post_action_no_response(self):
         rid = str(uuid.uuid4().hex)

--- a/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
+++ b/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
@@ -68,7 +68,7 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
         with mock.patch('oslo_messaging.notify._impl_log.LogDriver.notify') \
                 as driver:
             path = '/v2/' + self.project_id + '/servers'
-            app.get(path)
+            app.get(path, extra_environ=self.get_environ_header())
             # audit middleware conf has 'log' make sure that driver is invoked
             # and not the one specified in oslo_messaging_notifications section
             time.sleep(1)

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -1,6 +1,7 @@
 import json
 import os
 import uuid
+from builtins import str
 
 from pycadf import cadftaxonomy as taxonomy
 
@@ -317,12 +318,12 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     def test_list_namespaced(self):
         url = self.build_url('qos', prefix='/v2.0',
-                             child_res="policies")
+                             child_res="policies/bandwidth_limit_rules")
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_LIST,
-                         "network/qos/policies", None,
+                         "network/qos/bandwidth-limit-rules", None,
                          self.service_name)
 
     def test_post_create_multiple(self):
@@ -344,6 +345,10 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
             self.check_event(request, response, event, taxonomy.ACTION_CREATE,
                              "network/network",
                              items[idx]['id'], items[idx]['name'])
+
+    def test_put_custom_action(self):
+        """ "/v2.0/routers/0e7a2b1b-1b1a-428b-97b5-afd1a41c8f74
+        /remove_router_interface" """
 
 
 class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):

--- a/etc/nova_audit_map.yaml
+++ b/etc/nova_audit_map.yaml
@@ -77,6 +77,9 @@ resources:
     quota-class-sets:
         api_name: os-quota-class-sets
     servers:
+        payloads:
+            exclude:
+              - adminPass
         custom_actions:
             # server actions
             addFloatingIp: update/add/floatingip

--- a/tox.ini
+++ b/tox.ini
@@ -49,7 +49,7 @@ commands = oslo_debug_helper -t auditmiddleware/tests {posargs}
 # D203: 1 blank line required before class docstring (deprecated in pep257)
 ignore = D100,D101,D102,D103,D104,D203
 show-source = True
-exclude = .venv,.tox,dist,doc,*egg,build
+exclude = .venv,.tox,dist,doc,*egg,build,venv
 
 [testenv:docs]
 commands=


### PR DESCRIPTION
Those discovered resources are marked with an X-prefix, so they can be spotted easily.

Fixes #30