### PR TITLE
fix include/exclude syntax

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -97,13 +97,6 @@ def payloads_map(param):
 
     param['enabled'] = bool(param.get('enabled', True))
 
-    incl = param.get('include')
-    if incl:
-        param['include'] = [x.strip() for x in incl.split(',')]
-    excl = param.get('exclude')
-    if excl:
-        param['exclude'] = [x.strip() for x in excl.split(',')]
-
     return param
 
 

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -43,7 +43,8 @@ resources:
             custom_attr2: "/data/compute/server/custom"
         payloads:
             # hide this attribute from payload attachments
-            exclude: hidden_attr
+            exclude:
+              - hidden_attr
         children:
             interfaces:
                 api_name: os-interface


### PR DESCRIPTION
the configuration of the payload filter in the mapping file was a bit inapt in that it was using a single attribute with comma-separated values to list the attributes to be included resp. excluded.

In a proper YAML syntax such lists should be represented by lists. And that was what the documentation claimed.