### PR TITLE
fix dump on integer resource ID

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -524,7 +524,8 @@ class OpenStackAuditMiddleware(object):
         if payload:
             if isinstance(payload, dict):
                 name = payload.get(res_spec.name_field)
-                rid = rid or payload.get(res_spec.id_field)
+                # some custom ID fields are no UUIDs/strings but just integers
+                rid = rid or str(payload.get(res_spec.id_field))
 
                 project_id = (target_project or payload.get('project_id')
                               or payload.get('tenant_id'))

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -73,6 +73,35 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         self.check_event(request, response, event, taxonomy.ACTION_CREATE,
                          "compute/server/interface", port_id)
 
+    def test_post_create_agent_custom_id(self):
+        agent_id = 180
+        url = self.build_url('os-agents', prefix='/compute/v2.1')
+        req_json = {
+            u'agent': {
+                u'architecture': u'tempest-x86_64-831697749', 
+                u'hypervisor': u'common', 
+                u'md5hash': u'add6bb58e139be103324d04d82d8f545', 
+                u'os': u'linux', 
+                u'url': u'xxx://xxxx/xxx/xxx', 
+                u'version': u'7.0'
+            }
+        }
+        resp_json = {
+            u'agent_id': agent_id, 
+            u'architecture': u'tempest-x86_64-831697749', 
+            u'hypervisor': u'common', 
+            u'md5hash': u'add6bb58e139be103324d04d82d8f545', 
+            u'os': u'linux', 
+            u'url': u'xxx://xxxx/xxx/xxx', 
+            u'version': u'7.0'
+        }
+        request, response = self.build_api_call(
+            'POST', url, req_json=req_json, resp_json=resp_json)
+        event = self.build_event(request, response)
+
+        self.check_event(request, response, event, taxonomy.ACTION_CREATE,
+                         "compute/agent", str(uuid.UUID(int=agent_id)))
+     
     def test_put_global_action(self):
         url = self.build_url('os-services', prefix='/compute/v2.1',
                              suffix="disable")


### PR DESCRIPTION
compute/agent ID is an integer, not a string. That oddity currently breaks event creation.

this PR handles such integer resource IDs properly and adds a regression unit test