### PR TITLE
Fix unwanted sideeffect of attach_payload on original request payload / Cleanup

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,8 @@ install:
 - pip install tox-travis
 - pip install discover
 - pip install coverage
+- pip install coveralls
 script:
 - tox
 after_success:
-- coveralls
+- coveralls --service travis-ci

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,10 +14,10 @@ matrix:
   - python: "3.6"
     env:
     - TOXENV=py36
-#  - python: "3.7"
-#    dist: xenial
-#    env:
-#    - TOXENV=pep8
+  - python: "3.7"
+    dist: xenial
+    env:
+    - TOXENV=pep8
   - python: "3.7"
     dist: xenial
     env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,4 +26,7 @@ install:
 - pip install tox-travis
 - pip install discover
 - pip install coverage
-script: tox
+script:
+- tox
+after_success:
+- coveralls

--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ Some resources exist only once, i.e. they only have a single _instance_ and thus
 For some resources, some API designs do not follow the common OpenStack naming patterns. Those exceptions can be modelled with the following settings:
  * `api_name`: resource name in the URL path (default: `<resource-name>`); must be unique
  * `type_uri`: type-URI of the resource, used in the target.typeURI attribute of the produced CADF event (default: `<parent-typeURI>/<resource-name>`)
- * `el_type_uri`: type-URI of the resource instances if the resource is not a singleton (default: `type_uri` omitting the last character)
+ * `el_type_uri`: type-URI of the resource instances (default: `type_uri` omitting the last character); not applicable to singletons
  * `custom_id`: indicate which resource attribute contains the unique resource ID (default: `id`)
  * `custom_name`: indicate which resource attribute contains the resource readable name (default: `name`)
  * `type_name`: JSON name for the resource, used by API designs that wrap the resource attributes into a single top-level attribute (default: `api_name` without leading `os-` prefix resp. the original resource name, but with `-` replaced by `_`)

--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -11,12 +11,11 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
-"""
-Build open standard audit information based on incoming requests.
+"""Build open standard audit information based on incoming requests.
 
-AuditMiddleware filter should be placed after keystonemiddleware.auth_token
-in the pipeline so that it can utilise the information the Identity server
-provides.
+AuditMiddleware filter should be placed after
+keystonemiddleware.auth_token in the pipeline so that it can utilise the
+information the Identity server provides.
 """
 
 from auditmiddleware import _api

--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -91,6 +91,8 @@ def _log_and_ignore_error(fn):
 
 
 class ConfigError(BaseException):
+    """Exception for configuration errors."""
+
     pass
 
 
@@ -104,6 +106,12 @@ class AuditMiddleware(object):
     """
 
     def __init__(self, app, **conf):
+        """Initialize the middleware based on the application config.
+
+        Parameters:
+            app: the web application exteneded by this middleware
+            conf: the application specific configuration parameters as dict
+        """
         self._application = app
         self._conf = CONF
 
@@ -124,6 +132,7 @@ class AuditMiddleware(object):
 
     @_log_and_ignore_error
     def _process_request(self, request, response=None):
+        """Create & push events for request/response pair."""
         events = self._cadf_audit.create_events(request, response)
 
         if events:
@@ -134,6 +143,7 @@ class AuditMiddleware(object):
 
     @webob.dec.wsgify
     def __call__(self, req):
+        """Here is the actual application call that we are "decorating"."""
         if req.method in self._ignore_req_list:
             return req.get_response(self._application)
 

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -167,7 +167,8 @@ class OpenStackAuditMiddleware(object):
         descriptor.
 
         The descriptor contains all the information needed to produce
-        the CADF events from HTTP requests."""
+        the CADF events from HTTP requests.
+        """
 
         result = {}
 
@@ -187,7 +188,8 @@ class OpenStackAuditMiddleware(object):
             name: CADF name of the resource type
             parent_type_uri: type URI of the parent CADF resource type
                              (acting as prefix)
-            spec: mapping entry from the config to be parsed"""
+            spec: mapping entry from the config to be parsed
+        """
 
         if not spec:
             spec = {}
@@ -262,7 +264,8 @@ class OpenStackAuditMiddleware(object):
             response: resulting response to parse (e.g. to obtain results,
                       just created resource IDs)
             path: URL path being parsed
-            cursor: current position in the path as it is parsed"""
+            cursor: current position in the path as it is parsed
+        """
 
         # Check if the end of path is reached and event can be created finally
         if cursor == -1:
@@ -340,7 +343,8 @@ class OpenStackAuditMiddleware(object):
 
         The resulting events are a bit raw but contain enough
         information to understand what happened. This allows for
-        incremental improvement."""
+        incremental improvement.
+        """
 
         self._log.warning("unknown resource: %s (created on demand)",
                           token)
@@ -532,7 +536,7 @@ class OpenStackAuditMiddleware(object):
 
     @staticmethod
     def _clean_payload(payload, res_spec):
-        """Clean request payload of sensitive info"""
+        """Clean request payload of sensitive info."""
 
         incl = res_spec.payloads.get('include')
         excl = res_spec.payloads.get('exclude')
@@ -556,7 +560,7 @@ class OpenStackAuditMiddleware(object):
 
     @staticmethod
     def _attach_payload(event, payload, res_spec):
-        """Attach request payload to event"""
+        """Attach request payload to event."""
 
         res_payload = OpenStackAuditMiddleware._clean_payload(
             payload, res_spec)

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -183,7 +183,8 @@ class OpenStackAuditMiddleware(object):
 
         Parameters:
             name: CADF name of the resource type
-            parent_type_uri: type URI of the parent CADF resource type (acting as prefix)
+            parent_type_uri: type URI of the parent CADF resource type
+                             (acting as prefix)
             spec: mapping entry from the config to be parsed"""
 
         if not spec:
@@ -254,7 +255,8 @@ class OpenStackAuditMiddleware(object):
             res_id: ID of the target resource
             parent_res_id: ID of the parent resource of the target resource
             request: incoming request to parse
-            response: resulting response to parse (e.g. to obtain results, just created resource IDs)
+            response: resulting response to parse (e.g. to obtain results,
+                      just created resource IDs)
             path: URL path being parsed
             cursor: current position in the path as it is parsed"""
 
@@ -594,7 +596,8 @@ class OpenStackAuditMiddleware(object):
             else:
                 project_id = target_project
                 self._log.warning(
-                    "mapping error, malformed resource payload %s (no dict) in bulk operation on resource: %s",
+                    "mapping error, malformed resource payload %s (no dict) "
+                    "in bulk operation on resource: %s",
                     payload,
                     res_spec)
 
@@ -631,7 +634,8 @@ class OpenStackAuditMiddleware(object):
             action = self._get_action_from_payload(request, res_spec, res_id)
             return action, None
 
-        return self._get_action_and_key_from_path_suffix(suffix, request.method, res_spec, res_id)
+        return self._get_action_and_key_from_path_suffix(suffix, request.method,
+                    res_spec, res_id)
 
     @staticmethod
     def _get_action_from_method(method, res_spec, res_id):
@@ -713,7 +717,8 @@ class OpenStackAuditMiddleware(object):
 
         :param request: incoming request
         :return: URL request path without the leading prefix or None if prefix
-        was missing and optional target tenant or None"""
+        was missing and optional target tenant or None
+        """
 
         g = self._prefix_re.match(request.path)
         if g:

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -558,7 +558,8 @@ class OpenStackAuditMiddleware(object):
     def _attach_payload(event, payload, res_spec):
         """Attach request payload to event"""
 
-        res_payload = OpenStackAuditMiddleware._clean_payload(payload, res_spec)
+        res_payload = OpenStackAuditMiddleware._clean_payload(
+            payload, res_spec)
 
         attach_val = Attachment(typeURI="mime:application/json",
                                 content=json.dumps(res_payload,
@@ -623,8 +624,8 @@ class OpenStackAuditMiddleware(object):
             action = self._get_action_from_payload(request, res_spec, res_id)
             return action, None
 
-        return self._get_action_and_key_from_path_suffix(suffix, request.method,
-                    res_spec, res_id)
+        return self._get_action_and_key_from_path_suffix(
+            suffix, request.method, res_spec, res_id)
 
     @staticmethod
     def _get_action_from_method(method, res_spec, res_id):

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -492,7 +492,8 @@ class OpenStackAuditMiddleware(object):
         excl = res_spec.payloads.get('exclude')
         res_payload = {}
         if excl and isinstance(payload, dict):
-            res_payload = payload
+            # make a copy so we do not change the original request
+            res_payload = payload.copy()
             # remove possible wrapper elements
             for k in excl:
                 if k in res_payload:

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -93,8 +93,8 @@ def str_map(param):
         return {}
 
     for k, v in six.iteritems(param):
-        if v is not None and (not isinstance(k, six.string_types)
-                              or not isinstance(v, six.string_types)):
+        if v is not None and (not isinstance(k, six.string_types) or
+                              not isinstance(v, six.string_types)):
             raise Exception("Invalid config entry %s:%s (not strings)",
                             k, v)
 
@@ -115,9 +115,9 @@ def payloads_config(param):
 def _make_tags(ev):
     """Build statsd metric tags from CADF event."""
     return [
-        'project_id:{0}'.format(ev.target.project_id
-                                or ev.initiator.project_id
-                                or ev.initiator.domain_id),
+        'project_id:{0}'.format(ev.target.project_id or
+                                ev.initiator.project_id or
+                                ev.initiator.domain_id),
         'target_type_uri:{0}'.format(ev.target.typeURI),
         'action:{0}'.format(ev.action),
         'outcome:{0}'.format(ev.outcome)]
@@ -587,8 +587,8 @@ class OpenStackAuditMiddleware(object):
                 # some custom ID fields are no UUIDs/strings but just integers
                 rid = rid or str(payload.get(res_spec.id_field))
 
-                project_id = (target_project or payload.get('project_id')
-                              or payload.get('tenant_id'))
+                project_id = (target_project or payload.get('project_id') or
+                              payload.get('tenant_id'))
             else:
                 project_id = target_project
                 self._log.warning(

--- a/auditmiddleware/tests/__init__.py
+++ b/auditmiddleware/tests/__init__.py
@@ -1,0 +1,8 @@
+"""Regression tests for the audit-middleware.
+
+Currently only contains unit tests, shying away from the complexity of
+testing full integrations with OpenStack services and RabbitMQ. Due to
+the inherent modularity of paste pipeline filters, unit testing is quite
+sufficient here as long as the integration tests for the OpenStack
+services are run together with this middleware.
+"""

--- a/auditmiddleware/tests/__init__.py
+++ b/auditmiddleware/tests/__init__.py
@@ -19,3 +19,5 @@ the inherent modularity of paste pipeline filters, unit testing is quite
 sufficient here as long as the integration tests for the OpenStack
 services are run together with this middleware.
 """
+
+# empty

--- a/auditmiddleware/tests/__init__.py
+++ b/auditmiddleware/tests/__init__.py
@@ -1,3 +1,16 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
 """Regression tests for the audit-middleware.
 
 Currently only contains unit tests, shying away from the complexity of

--- a/auditmiddleware/tests/__init__.py
+++ b/auditmiddleware/tests/__init__.py
@@ -19,5 +19,3 @@ the inherent modularity of paste pipeline filters, unit testing is quite
 sufficient here as long as the integration tests for the OpenStack
 services are run together with this middleware.
 """
-
-# empty

--- a/auditmiddleware/tests/unit/__init__.py
+++ b/auditmiddleware/tests/unit/__init__.py
@@ -24,5 +24,3 @@ The tests here cover the following aspects:
     - validity of the mapping files for the various OpenStack services
       (test_mappings.py)
 """
-
-# empty

--- a/auditmiddleware/tests/unit/__init__.py
+++ b/auditmiddleware/tests/unit/__init__.py
@@ -1,0 +1,9 @@
+"""Unit tests for the audit-middleware.
+
+The tests here cover the following aspects:
+    - proper integration into the paste pipeline of OpenStack services  (test_audit_middleware.py)
+    - completeness and correctness of CADF events created from OpenStack API calls (test_audit_filter.py)
+    - correct interaction with oslo messaging (test_audit_oslo_messaging.py)
+    - sustained availability when the message broker is down and fallback to logging output (test_logging_notifier.py)
+    - validity of the mapping files for the various OpenStack services (test_mappings.py)
+"""

--- a/auditmiddleware/tests/unit/__init__.py
+++ b/auditmiddleware/tests/unit/__init__.py
@@ -24,3 +24,5 @@ The tests here cover the following aspects:
     - validity of the mapping files for the various OpenStack services
       (test_mappings.py)
 """
+
+# empty

--- a/auditmiddleware/tests/unit/__init__.py
+++ b/auditmiddleware/tests/unit/__init__.py
@@ -1,9 +1,26 @@
+#
+# Licensed under the Apache License, Version 2.0 (the "License"); you may
+# not use this file except in compliance with the License. You may obtain
+# a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+# WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+# License for the specific language governing permissions and limitations
+# under the License.
+
 """Unit tests for the audit-middleware.
 
 The tests here cover the following aspects:
-    - proper integration into the paste pipeline of OpenStack services  (test_audit_middleware.py)
-    - completeness and correctness of CADF events created from OpenStack API calls (test_audit_filter.py)
+    - proper integration into the paste pipeline of OpenStack services
+      (test_audit_middleware.py)
+    - completeness and correctness of CADF events created from OpenStack API
+      calls (test_audit_filter.py)
     - correct interaction with oslo messaging (test_audit_oslo_messaging.py)
-    - sustained availability when the message broker is down and fallback to logging output (test_logging_notifier.py)
-    - validity of the mapping files for the various OpenStack services (test_mappings.py)
+    - sustained availability when the message broker is down and fallback to
+      logging output (test_logging_notifier.py)
+    - validity of the mapping files for the various OpenStack services
+      (test_mappings.py)
 """

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -9,19 +9,21 @@
 # WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
 # License for the specific language governing permissions and limitations
 # under the License.
-import uuid
 
-import webob
-import webob.dec
+"""Base functionality for all tests."""
+
+import auditmiddleware
+from auditmiddleware._api import _make_tags
+from auditmiddleware.tests.unit import utils
 from mock import mock
 from oslo_config import fixture as cfg_fixture
 from oslo_messaging import conffixture as msg_fixture
 from oslotest import createfile
 from testtools.matchers import MatchesRegex
+import uuid
+import webob
+import webob.dec
 
-import auditmiddleware
-from auditmiddleware._api import _make_tags
-from auditmiddleware.tests.unit import utils
 
 iso8601 = r'^\d{4}-\d\d-\d\dT\d\d:\d\d:\d\d\.\d{6}[+-]\d\d:\d\d$'
 
@@ -72,6 +74,12 @@ user_counter = 0
 
 
 class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
+    """Base class of all auditmiddleware tests.
+
+    Takes care of middleware configuration, scoping and common
+    functionality to build fixtures and validate test outcomes.
+    """
+
     def setUp(self):
         """Set up common parts of all test-cases here."""
         super(BaseAuditMiddlewareTest, self).setUp()
@@ -136,7 +144,6 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
 
     def get_environ_header(self, req_type=None):
         """Provide the headers usually the keystonemiddleware would provide."""
-
         env_headers = {'HTTP_X_USER_ID': self.user_id,
                        'HTTP_X_USER_NAME': self.username,
                        'HTTP_X_AUTH_TOKEN': 'token',
@@ -149,11 +156,12 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
     def build_event(self, req, resp=None, middleware_cfg=None,
                     record_payloads=False, metrics_enabled=True):
         """Trigger the creation of a single event from a request/response.
-        
+
         Parameters:
             req: webob request
             resp: webeb response (unless we have a negative test)
-            middleware_cfg (optional): override standard path to the mapping file
+            middleware_cfg (optional): override standard path to the mapping
+                file
             record_payloads: option to add request payloads to the CADF event
             metrics_enabled: enable/disable creation of metrics
         """
@@ -167,8 +175,8 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
                 payload_attachment = [x['name'] for x in ev['attachments']]
                 self.assertIn('payload', payload_attachment,
                               'payload attachment missing')
-                self.assertEquals(1, payload_attachment.count('payload'),
-                                  "too many payload attachments")
+                self.assertEqual(1, payload_attachment.count('payload'),
+                                 "too many payload attachments")
             else:
                 self.assertNotIn('payload',
                                  [x['name'] for x in ev.get('attachments',
@@ -184,8 +192,10 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
 
         Parameters:
             req: webob request
-            resp: webeb response (unless we have a negative test)
-            middleware_cfg (optional): override standard path to the mapping file
+            resp: webeb response (unless we have a negative
+                test)
+            middleware_cfg (optional): override standard path to the mapping
+                file
             record_payloads: option to add request payloads to the CADF event
             metrics_enabled: enable/disable creation of metrics
         """
@@ -286,21 +296,20 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
             self.assertEqual(event['reason']['reasonCode'],
                              str(response.status_code))
 
-        # TODO check observer
         self.assertEqual(event['requestPath'], request.path)
 
     def build_url(self, res, host_url=None, prefix='', suffix=None,
                   res_id=None,
                   child_res=None, child_res_id=None):
         """Build a REST URL.
-        
+
         Parameters:
             res: name of the target resource type
             host_url: URL without path
             prefix: prefix of the URL path (e.g. v2/<tenant>)
             res_id: object ID of the resource
             child_res: target child resource (if target is nested)
-            child_res_id: object ID of child resource 
+            child_res_id: object ID of child resource
         """
         url = host_url if host_url else 'http://admin_host:8774' + prefix
         url += '/' + res

--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -74,7 +74,6 @@ user_counter = 0
 class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
     def setUp(self):
         """Set up common parts of all test-cases here."""
-
         super(BaseAuditMiddlewareTest, self).setUp()
 
         global user_counter
@@ -108,7 +107,6 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
             value: expected value of said metric
             tags: tags associated with the metric (dimensions)
         """
-
         self.statsd_report_mock.assert_any_call(metric, 'c', value, tags, 1)
 
     def assert_statsd_gauge(self, metric, value, tags=None):
@@ -119,12 +117,10 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
             value: expected value of said metric
             tags: tags associated with the metric (dimensions)
         """
-
         self.statsd_report_mock.assert_any_call(metric, 'g', value, tags, 1)
 
     def create_middleware(self, cb, **kwargs):
         """Implement abstract method from base class."""
-
         @webob.dec.wsgify
         def _do_cb(req):
             return cb(req)
@@ -136,7 +132,6 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
     @property
     def audit_map(self):
         """Path to the audit mapping file used for this test-case."""
-
         return self.audit_map_file_fixture.path
 
     def get_environ_header(self, req_type=None):
@@ -153,9 +148,8 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
 
     def build_event(self, req, resp=None, middleware_cfg=None,
                     record_payloads=False, metrics_enabled=True):
-        """Trigger the actual creation of an event from request/response
-        fixture.
-
+        """Trigger the creation of a single event from a request/response.
+        
         Parameters:
             req: webob request
             resp: webeb response (unless we have a negative test)
@@ -163,7 +157,6 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
             record_payloads: option to add request payloads to the CADF event
             metrics_enabled: enable/disable creation of metrics
         """
-
         event_list = self.build_event_list(req, resp, middleware_cfg,
                                            record_payloads, metrics_enabled)
         if event_list:
@@ -187,6 +180,15 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
 
     def build_event_list(self, req, resp=None, middleware_cfg=None,
                          record_payloads=False, metrics_enabled=True):
+        """Trigger the actual creation of events from a request/response.
+
+        Parameters:
+            req: webob request
+            resp: webeb response (unless we have a negative test)
+            middleware_cfg (optional): override standard path to the mapping file
+            record_payloads: option to add request payloads to the CADF event
+            metrics_enabled: enable/disable creation of metrics
+        """
         cfg = middleware_cfg or self.audit_map
         middleware = auditmiddleware._api.OpenStackAuditMiddleware(
             cfg, record_payloads, metrics_enabled=metrics_enabled)
@@ -204,6 +206,17 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
     def build_api_call(self, method, url, req_json=None,
                        resp_json=None, resp_code=0,
                        environ=None):
+        """Build a request/response pair for testing.
+
+        This method assumes JSON contents in both.
+
+        Parameters:
+            method: HTTP method
+            url: URL
+            req_json: request payload as dict
+            resp_json: response payload as dict
+            environ: HTTP headers if default ones do not fit
+        """
         environ = environ or self.get_environ_header()
         req = webob.Request.blank(url,
                                   body=None,
@@ -240,9 +253,7 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
                     target_id=None,
                     target_name=None,
                     outcome="success"):
-        """Assert that the service-independent information in the produced CADF
-        events is complete and valid."""
-
+        """Check the service-independent parts of an event."""
         self.assertIsNotNone(event, "missing event")
         self.assertEqual(event['action'], action)
         self.assertEqual(event['typeURI'],
@@ -281,6 +292,16 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
     def build_url(self, res, host_url=None, prefix='', suffix=None,
                   res_id=None,
                   child_res=None, child_res_id=None):
+        """Build a REST URL.
+        
+        Parameters:
+            res: name of the target resource type
+            host_url: URL without path
+            prefix: prefix of the URL path (e.g. v2/<tenant>)
+            res_id: object ID of the resource
+            child_res: target child resource (if target is nested)
+            child_res_id: object ID of child resource 
+        """
         url = host_url if host_url else 'http://admin_host:8774' + prefix
         url += '/' + res
         url += '/' + res_id if res_id else ''

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -449,7 +449,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         request, response = self.build_api_call('POST', url)
         event = self.build_event(request, response)
 
-        self.assertEqual(None, event, "Event should have been suppressed")
+        self.assertIsNone(event, "Event should have been suppressed")
 
     def test_post_action_suppressed(self):
         """Test rules for path-encoded actions.
@@ -463,7 +463,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         request, response = self.build_api_call('POST', url)
         event = self.build_event(request, response)
 
-        self.assertEqual(None, event, "Event should have been suppressed")
+        self.assertIsNone(event, "Event should have been suppressed")
 
     def test_get_action_generic(self):
         """Test generic rules for path-encoded actions.
@@ -496,8 +496,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                                                 req_json=payload_content)
         event = self.build_event(request, response, record_payloads=True)
 
-        self.check_event(request, response, event, taxonomy.ACTION_UPDATE
-                         + "/set",
+        self.check_event(request, response, event, taxonomy.ACTION_UPDATE +
+                         "/set",
                          "compute/server/metadata", rid)
         key_attachment = {'name': 'key',
                           'typeURI': 'xs:string',
@@ -542,8 +542,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         request, response = self.build_api_call('POST', url,
                                                 req_json={"unknown": "bla"})
         event = self.build_event(request, response)
-        self.check_event(request, response, event, taxonomy.ACTION_UPDATE
-                         + "/unknown", "compute/server", rid)
+        self.check_event(request, response, event, taxonomy.ACTION_UPDATE +
+                         "/unknown", "compute/server", rid)
 
     def test_post_resource_undeclared(self):
         """Test that resource paths w/o mapping are still causing events.

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -93,7 +93,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_patch_custom_attr(self):
         """Test selective update of custom resource attributes using HTTP
-        PATCH."""
+        PATCH.
+        """
         rid = str(uuid.uuid4().hex)
         custom_value = {'child1': 'test'}
         # such API does not exist in Nova
@@ -146,7 +147,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_delete_all(self):
         """Test deletion of all child-resources at once, i.e. delete w/o child
-        ID."""
+        ID.
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid, child_res='tags')
@@ -241,7 +243,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_get_singleton_child_read_key(self):
         """Test reading keys (custom attributes) from singleton child
-        resources."""
+        resources.
+        """
         rid = str(uuid.uuid4().hex)
         # this property is modelled as custom action
         key = "server_meta_key"
@@ -275,7 +278,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_create_rec_payload(self):
         """Test presence of payload attachment when payload recording is
-        active."""
+        active.
+        """
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -298,7 +302,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_create_neutron_style(self):
         """Test creation of resources using HTTP POST with target project-id in
-        the URL."""
+        the URL.
+        """
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -369,7 +374,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_create_multiple_cross_project_wrapped(self):
         """Test batch creation of resources with a mixture of target projects
-        using HTTP POST."""
+        using HTTP POST.
+        """
         items = [{'id': str(uuid.uuid4().hex), 'name': 'name-' + str(i),
                   'project_id': str(uuid.uuid4().hex)} for
                  i in range(3)]
@@ -438,7 +444,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_action_generic_suppressed(self):
         """test generic rules for path-encoded actions: suppress event via null
-        e.g. "POST:*": null"."""
+        e.g. "POST:*": null".
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="arbitrary", res_id=rid)
@@ -449,7 +456,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_action_suppressed(self):
         """test generic rules for path-encoded actions: suppress event via null
-        e.g. "POST:*": null"."""
+        e.g. "POST:*": null".
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="suppressed", res_id=rid)
@@ -473,6 +481,10 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_put_key(self):
+        """Test attaching custom attributes (keys) to resources.
+
+        Keys are used to add user-defined attributes to resources.
+        """
         rid = str(uuid.uuid4().hex)
         key = "somekey"
         payload_content = {"meta": {key: "ignored here"}}
@@ -500,6 +512,11 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "event attachments should contain payload")
 
     def test_post_action_missing_payload(self):
+        """Test that actions lacking a payload cause no event.
+
+        Custom actions that do not created resources, do not always
+        create a response message.
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="action", res_id=rid)
@@ -510,6 +527,14 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                                  "be ignored")
 
     def test_post_undefined_action_generic(self):
+        """Test that actions w/o declared mapping are still causing events.
+
+        Actions encoded in the payload do not need require a mapping entry
+        if they follow the standard OpenStack pattern for actions.
+
+        That pattern is that the URL path ends with `/action` and the
+        JSON payload has a root attribute named after the action.
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="action", res_id=rid)
@@ -520,6 +545,11 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          + "/unknown", "compute/server", rid)
 
     def test_post_resource_undeclared(self):
+        """Test that resource paths w/o mapping are still causing events.
+
+        Those events can be spotted by the "X" prefixing the resource
+        name derived from the URL path.
+        """
         rid = str(uuid.uuid4().hex)
         rname = "myname"
         url = self.build_url('yetunknowns', prefix='/v2/' + self.project_id)
@@ -532,6 +562,11 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/Xyetunknown", rid, rname)
 
     def test_put_resource_undeclared(self):
+        """Test that resource paths w/o mapping are still causing events.
+
+        Those events can be spotted by the "X" prefixing the resource
+        name derived from the URL path.
+        """
         rid = str(uuid.uuid4().hex)
         rid2 = str(uuid.uuid4().hex)
         url = self.build_url('yetunknowns', prefix='/v2/' + self.project_id,
@@ -544,6 +579,11 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/Xyetunknown/Xuchild", rid2)
 
     def test_post_action_no_response(self):
+        """Test events are created for POST actions with no response payload.
+
+        The implementation must not assume that a response always has a
+        payload.
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="action", res_id=rid)
@@ -555,6 +595,10 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_get_service_action(self):
+        """Test singleton actions directed at a service.
+
+        Those should create events where the target has no ID but a name
+        """
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="detail")
         request, response = self.build_api_call('GET', url)

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -24,6 +24,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         self.service_type = 'compute'
 
     def test_get_list(self):
+        """Test listing of resources using GET"""
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -33,8 +34,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          self.service_name)
 
     def test_get_list_child(self):
+        """Test listing of resource children using GET"""
         rid = str(uuid.uuid4().hex)
-        # this property is modelled as singleton
         key = "os-volume_attachments"
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid, child_res=key)
@@ -45,6 +46,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/volume-attachments", rid)
 
     def test_get_read(self):
+        """Test reading of resources using HTTP GET"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -55,6 +57,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_head_read(self):
+        """Test existence of resources using HTTP HEAD"""
         rid = str(uuid.uuid4().hex)
         # such API does not exist in Nova
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -66,6 +69,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_put(self):
+        """Test upsert of resources using HTTP PUT"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -76,6 +80,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_patch(self):
+        """Test selective update of resource attributes using HTTP PATCH"""
         rid = str(uuid.uuid4().hex)
         # such API does not exist in Nova
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -87,6 +92,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_patch_custom_attr(self):
+        """Test selective update of custom resource attributes using HTTP PATCH"""
         rid = str(uuid.uuid4().hex)
         custom_value = {'child1': 'test'}
         # such API does not exist in Nova
@@ -110,6 +116,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain custom_attr value")
 
     def test_delete(self):
+        """Test deletion of resources using HTTP DELETE"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -119,12 +126,10 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         self.check_event(request, response, event, taxonomy.ACTION_DELETE,
                          "compute/server", rid)
 
-    #  /v2/a759dcc2a2384a76b0386bb985952373/servers/805780cd-9934-42bd-a0b3
-    # -6db177a656b5/os-volume_attachments/e733127c-4bae-429c-bd01-a89ff0b109a2
     def test_delete_child(self):
-        """ verify fix for
-        https://github.com/sapcc/openstack-audit-middleware/issues/8
-        """
+        """Test deletion of child resources using HTTP DELETE
+
+        regression test for https://github.com/sapcc/openstack-audit-middleware/issues/8"""
         rid = str(uuid.uuid4().hex)
         rid2 = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -138,9 +143,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/volume-attachment", rid2)
 
     def test_delete_all(self):
-        """ delete all child-resources at once, i.e. delete w/o child ID
-        :return:
-        """
+        """Test deletion of all child-resources at once, i.e. delete w/o child ID"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid, child_res='tags')
@@ -151,6 +154,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/tags", rid)
 
     def test_delete_fail(self):
+        """Test proper event for failed resource delete actions"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -173,6 +177,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
     #
 
     def test_post_update(self):
+        """Test resource updates using HTTP POST"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -183,6 +188,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_put_update_child(self):
+        """Test child resource updates using HTTP PUT"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid, child_res="metadata")
@@ -193,6 +199,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/metadata", rid)
 
     def test_put_singleton_key(self):
+        """Test setting keys (custom attributes) from singleton resources"""
         rid = str(uuid.uuid4().hex)
         key = "server_meta_key"
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -211,6 +218,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key " + key)
 
     def test_delete_singleton_key(self):
+        """Test deleting keys (custom attributes) from singleton resources"""
         rid = str(uuid.uuid4().hex)
         key = "server_meta_key"
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -229,6 +237,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key " + key)
 
     def test_get_singleton_child_read_key(self):
+        """Test reading keys (custom attributes) from singleton child resources"""
         rid = str(uuid.uuid4().hex)
         # this property is modelled as custom action
         key = "server_meta_key"
@@ -248,6 +257,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key " + key)
 
     def test_post_create(self):
+        """Test resource creation using HTTP POST"""
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -260,6 +270,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid, rname)
 
     def test_post_create_rec_payload(self):
+        """Test presence of payload attachment when payload recording is active"""
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -281,6 +292,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "event attachments should contain payload")
 
     def test_post_create_neutron_style(self):
+        """Test creation of resources using HTTP POST with target project-id in the URL"""
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -292,6 +304,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid, rname)
 
     def test_post_create_cross_project_wrapped(self):
+        """Test creation of resources in another project using HTTP POST"""
         rid = str(uuid.uuid4().hex)
         pid = str(uuid.uuid4().hex)
         rname = 'server1'
@@ -308,6 +321,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "project_id for cross-project create actions")
 
     def test_post_create_multiple_wrapped(self):
+        """Test batch creation of resources using HTTP POST"""
         items = [{'id': str(uuid.uuid4().hex), 'name': 'name-' + str(i),
                   'custom_attr': 'custom-' + str(i),
                   'hidden_attr': 'hidden-' + str(i)} for i in range(3)]
@@ -348,8 +362,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                           "attachment should contain custom_attr value")
 
     def test_post_create_multiple_cross_project_wrapped(self):
-        """ test cross-project batch creation.
-        """
+        """Test batch creation of resources with a mixture of target projects using HTTP POST"""
         items = [{'id': str(uuid.uuid4().hex), 'name': 'name-' + str(i),
                   'project_id': str(uuid.uuid4().hex)} for
                  i in range(3)]
@@ -385,6 +398,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                           "event attachments should contain payload")
 
     def test_post_create_child(self):
+        """Test creation of child resources via HTTP POST"""
         rid = str(uuid.uuid4().hex)
         child_rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -397,6 +411,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/interface", target_id=child_rid)
 
     def test_post_action(self):
+        """Test invocation of custom actions via HTTP POST"""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="action", res_id=rid)
@@ -543,7 +558,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/servers", None,
                          self.service_name)
 
-        # TODO: fix and enable for Swift
+        # this test needs to be passed for Swift. Currently audit-middleware does not support
+        # the REST patterns implemented by Swift
         # def test_no_auth_token(self):
         #     # Test cases where API requests such as Swift list public
         # containers

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -24,7 +24,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         self.service_type = 'compute'
 
     def test_get_list(self):
-        """Test listing of resources using GET"""
+        """Test listing of resources using GET."""
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -34,7 +34,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          self.service_name)
 
     def test_get_list_child(self):
-        """Test listing of resource children using GET"""
+        """Test listing of resource children using GET."""
         rid = str(uuid.uuid4().hex)
         key = "os-volume_attachments"
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -46,7 +46,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/volume-attachments", rid)
 
     def test_get_read(self):
-        """Test reading of resources using HTTP GET"""
+        """Test reading of resources using HTTP GET."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -57,7 +57,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_head_read(self):
-        """Test existence of resources using HTTP HEAD"""
+        """Test existence of resources using HTTP HEAD."""
         rid = str(uuid.uuid4().hex)
         # such API does not exist in Nova
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -69,7 +69,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_put(self):
-        """Test upsert of resources using HTTP PUT"""
+        """Test upsert of resources using HTTP PUT."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -80,7 +80,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_patch(self):
-        """Test selective update of resource attributes using HTTP PATCH"""
+        """Test selective update of resource attributes using HTTP PATCH."""
         rid = str(uuid.uuid4().hex)
         # such API does not exist in Nova
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -92,7 +92,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_patch_custom_attr(self):
-        """Test selective update of custom resource attributes using HTTP PATCH"""
+        """Test selective update of custom resource attributes using HTTP
+        PATCH."""
         rid = str(uuid.uuid4().hex)
         custom_value = {'child1': 'test'}
         # such API does not exist in Nova
@@ -116,7 +117,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain custom_attr value")
 
     def test_delete(self):
-        """Test deletion of resources using HTTP DELETE"""
+        """Test deletion of resources using HTTP DELETE."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -127,9 +128,10 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_delete_child(self):
-        """Test deletion of child resources using HTTP DELETE
+        """Test deletion of child resources using HTTP DELETE.
 
-        regression test for https://github.com/sapcc/openstack-audit-middleware/issues/8"""
+        regression test for https://github.com/sapcc/openstack-audit-middleware/issues/8
+        """
         rid = str(uuid.uuid4().hex)
         rid2 = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -143,7 +145,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/volume-attachment", rid2)
 
     def test_delete_all(self):
-        """Test deletion of all child-resources at once, i.e. delete w/o child ID"""
+        """Test deletion of all child-resources at once, i.e. delete w/o child
+        ID."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid, child_res='tags')
@@ -154,7 +157,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/tags", rid)
 
     def test_delete_fail(self):
-        """Test proper event for failed resource delete actions"""
+        """Test proper event for failed resource delete actions."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -177,7 +180,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
     #
 
     def test_post_update(self):
-        """Test resource updates using HTTP POST"""
+        """Test resource updates using HTTP POST."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid)
@@ -188,7 +191,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid)
 
     def test_put_update_child(self):
-        """Test child resource updates using HTTP PUT"""
+        """Test child resource updates using HTTP PUT."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              res_id=rid, child_res="metadata")
@@ -199,7 +202,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/metadata", rid)
 
     def test_put_singleton_key(self):
-        """Test setting keys (custom attributes) from singleton resources"""
+        """Test setting keys (custom attributes) from singleton resources."""
         rid = str(uuid.uuid4().hex)
         key = "server_meta_key"
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -218,7 +221,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key " + key)
 
     def test_delete_singleton_key(self):
-        """Test deleting keys (custom attributes) from singleton resources"""
+        """Test deleting keys (custom attributes) from singleton resources."""
         rid = str(uuid.uuid4().hex)
         key = "server_meta_key"
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -237,7 +240,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key " + key)
 
     def test_get_singleton_child_read_key(self):
-        """Test reading keys (custom attributes) from singleton child resources"""
+        """Test reading keys (custom attributes) from singleton child
+        resources."""
         rid = str(uuid.uuid4().hex)
         # this property is modelled as custom action
         key = "server_meta_key"
@@ -257,7 +261,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key " + key)
 
     def test_post_create(self):
-        """Test resource creation using HTTP POST"""
+        """Test resource creation using HTTP POST."""
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -270,7 +274,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid, rname)
 
     def test_post_create_rec_payload(self):
-        """Test presence of payload attachment when payload recording is active"""
+        """Test presence of payload attachment when payload recording is
+        active."""
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -292,7 +297,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                       "event attachments should contain payload")
 
     def test_post_create_neutron_style(self):
-        """Test creation of resources using HTTP POST with target project-id in the URL"""
+        """Test creation of resources using HTTP POST with target project-id in
+        the URL."""
         rid = str(uuid.uuid4().hex)
         rname = 'server1'
         url = self.build_url('servers', prefix='/v2/' + self.project_id)
@@ -304,7 +310,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server", rid, rname)
 
     def test_post_create_cross_project_wrapped(self):
-        """Test creation of resources in another project using HTTP POST"""
+        """Test creation of resources in another project using HTTP POST."""
         rid = str(uuid.uuid4().hex)
         pid = str(uuid.uuid4().hex)
         rname = 'server1'
@@ -321,7 +327,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "project_id for cross-project create actions")
 
     def test_post_create_multiple_wrapped(self):
-        """Test batch creation of resources using HTTP POST"""
+        """Test batch creation of resources using HTTP POST."""
         items = [{'id': str(uuid.uuid4().hex), 'name': 'name-' + str(i),
                   'custom_attr': 'custom-' + str(i),
                   'hidden_attr': 'hidden-' + str(i)} for i in range(3)]
@@ -362,7 +368,8 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                           "attachment should contain custom_attr value")
 
     def test_post_create_multiple_cross_project_wrapped(self):
-        """Test batch creation of resources with a mixture of target projects using HTTP POST"""
+        """Test batch creation of resources with a mixture of target projects
+        using HTTP POST."""
         items = [{'id': str(uuid.uuid4().hex), 'name': 'name-' + str(i),
                   'project_id': str(uuid.uuid4().hex)} for
                  i in range(3)]
@@ -398,7 +405,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                           "event attachments should contain payload")
 
     def test_post_create_child(self):
-        """Test creation of child resources via HTTP POST"""
+        """Test creation of child resources via HTTP POST."""
         rid = str(uuid.uuid4().hex)
         child_rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
@@ -411,7 +418,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
                          "compute/server/interface", target_id=child_rid)
 
     def test_post_action(self):
-        """Test invocation of custom actions via HTTP POST"""
+        """Test invocation of custom actions via HTTP POST."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="action", res_id=rid)
@@ -431,8 +438,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_action_generic_suppressed(self):
         """test generic rules for path-encoded actions: suppress event via null
-        e.g. "POST:*": null"
-        """
+        e.g. "POST:*": null"."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="arbitrary", res_id=rid)
@@ -443,8 +449,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
 
     def test_post_action_suppressed(self):
         """test generic rules for path-encoded actions: suppress event via null
-        e.g. "POST:*": null"
-        """
+        e.g. "POST:*": null"."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,
                              suffix="suppressed", res_id=rid)
@@ -454,8 +459,9 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         self.assertEqual(None, event, "Event should have been suppressed")
 
     def test_get_action_generic(self):
-        """test generic rules for path-encoded actions
-        e.g. "GET:*": "read/*"
+        """test generic rules for path-encoded actions e.g. "GET:*":
+
+        "read/*".
         """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('servers', prefix='/v2/' + self.project_id,

--- a/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
+++ b/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
@@ -83,12 +83,12 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
         # and not the one specified in oslo_messaging_notifications section
         path = '/v2/' + self.project_id + '/servers'
         invocations = 3
-        for i in range(0, invocations):
+        for _ in range(0, invocations):
             app.get(path, extra_environ=self.get_environ_header())
         # check that the backlog has grown
         self.assert_statsd_gauge('backlog', 1)
         time.sleep(1)
-        for i in range(0, invocations):
+        for _ in range(0, invocations):
             delay()
         self.assertTrue(driver.called)
         # check that the backlog has been reset

--- a/auditmiddleware/tests/unit/test_logging_notifier.py
+++ b/auditmiddleware/tests/unit/test_logging_notifier.py
@@ -10,15 +10,18 @@
 # License for the specific language governing permissions and limitations
 # under the License.
 
+"""Tests for the logging driver."""
+
+from auditmiddleware.tests.unit import base
 import fixtures
 import mock
 
-from auditmiddleware.tests.unit import base
-
 
 class TestLoggingNotifier(base.BaseAuditMiddlewareTest):
+    """Test the 'log' driver for notifications."""
 
     def setUp(self):
+        """Set up the test by patching the messaging layer."""
         p = 'auditmiddleware._notifier.oslo_messaging'
         f = fixtures.MockPatch(p, None)
         self.messaging_fixture = self.useFixture(f)
@@ -26,6 +29,7 @@ class TestLoggingNotifier(base.BaseAuditMiddlewareTest):
         super(TestLoggingNotifier, self).setUp()
 
     def test_api_request_no_messaging(self):
+        """Test that logging works and event_type is correct."""
         app = self.create_simple_app()
 
         with mock.patch('auditmiddleware._LOG.info') as log:

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -227,8 +227,8 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/floatingip", rid)
 
     def test_post_create_ports(self):
-        """ regression test introduced to explain the issue with determining
-        the target project of service calls to neutron api.
+        """regression test introduced to explain the issue with determining the
+        target project of service calls to neutron api.
 
         The problem here was that instead of project_id, our Neutron
         version returned tenant_id ONLY.
@@ -323,8 +323,7 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain security_groups value")
 
     def test_post_create_namespaced(self):
-        """ tests the use of singleton resources for namespace prefixes
-        """
+        """tests the use of singleton resources for namespace prefixes."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('fwaas', prefix='/v2.0',
                              child_res="firewall_groups")
@@ -336,9 +335,8 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/firewall", target_id=rid)
 
     def test_post_create_merged_namespaced(self):
-        """ check whether to namespace-like resources can be mapped to the
-        same type URI
-        """
+        """check whether to namespace-like resources can be mapped to the same
+        type URI."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('fw', prefix='/v2.0',
                              child_res="firewalls")
@@ -391,8 +389,10 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                              items[idx]['id'], items[idx]['name'])
 
     def test_put_custom_action(self):
-        """ "/v2.0/routers/0e7a2b1b-1b1a-428b-97b5-afd1a41c8f74
-        /remove_router_interface" """
+        """"/v2.0/routers/0e7a2b1b-1b1a-428b-97b5-afd1a41c8f74.
+
+        /remove_router_interface"
+        """
 
 
 class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -179,8 +179,8 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         })
         event = self.build_event(request, response)
 
-        self.check_event(request, response, event, taxonomy.ACTION_UPDATE
-                         + "/set", "compute/services", None,
+        self.check_event(request, response, event, taxonomy.ACTION_UPDATE +
+                         "/set", "compute/services", None,
                          self.service_name)
         key_attachment = {'name': 'key',
                           'typeURI': 'xs:string',
@@ -200,8 +200,8 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         request, response = self.build_api_call('PUT', url)
         event = self.build_event(request, response)
 
-        self.check_event(request, response, event, taxonomy.ACTION_UPDATE
-                         + "/set", "compute/server/tags",
+        self.check_event(request, response, event, taxonomy.ACTION_UPDATE +
+                         "/set", "compute/server/tags",
                          "c489798d-8031-406d-aabb-0040a3b7b4be")
         key_attachment = {'typeURI': 'xs:string', 'content': 'tag-1234',
                           'name': 'key'}
@@ -526,8 +526,8 @@ class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
 
-        self.check_event(request, response, event, taxonomy.ACTION_READ
-                         + "/acl", "storage/volume/type", rid, None,
+        self.check_event(request, response, event, taxonomy.ACTION_READ +
+                         "/acl", "storage/volume/type", rid, None,
                          "success")
 
 

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -13,7 +13,7 @@
 """Smoke tests for our mapping files.
 
 These tests cover all the ugly corner-cases that arose when
-elaborating the mappings from the API documentation.
+working out the mappings from the API documentation.
 """
 
 from auditmiddleware.tests.unit import base
@@ -44,11 +44,11 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     @property
     def audit_map(self):
-        """audit_map attribute."""
+        """The audit mapping filename under test."""
         return self.audit_map_file_fixture
 
     def test_get_list(self):
-        """Test listing a resource (GET w/o object ID)."""
+        """Test listing items of a resource (GET w/o object ID)."""
         url = self.build_url('servers', prefix='/compute/v2.1')
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -58,7 +58,13 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          None, self.service_name)
 
     def test_get_list_os_migrations(self):
-        """Test resource names in the URL path can be renamed.""" 
+        """Test mapping distinct API paths to same resource type.
+
+        In the mapping file there are two different resource mappings,
+        `migrations` and `migrations_legacy_api` which have different
+        api names (path segments) but share the same resource typeURI
+        since they represent two different interfaces for the same thing.
+        """
         url = self.build_url('os-migrations', prefix='/compute/v2.1')
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -68,14 +74,13 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          None, self.service_name)
 
     def test_get_read(self):
-        """Test that the os-prefix in the path is omitted.
-        
-        When deriving the name of the attribute containing
-        the resource contents (JSON type name) from the
-        path segment representing the resource (API name),
-        any 'os-' prefix needs to be omitted.
+        """Test that the os-prefix in the path is left out in JSON by default.
+
+        When deriving the JSON type name (the name of the attribute wrapping
+        the resource contents) from the API name (the path segment
+        representing the resource), the 'os-' prefix common in
+        legacy API versions needs to be omitted.
         """
-    # the api_name
         rid = str(uuid.uuid4().hex)
         url = self.build_url('os-hypervisors', prefix='/compute/v2.1',
                              res_id=rid)
@@ -87,8 +92,13 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         self.check_event(request, response, event, taxonomy.ACTION_READ,
                          "compute/hypervisor", rid)
 
-    # ensure the customized JSON type name is used
     def test_post_create_interface_attachment(self):
+        """Test that the customized JSON type name is used.
+
+        Without the customization, the resource either would have to be named
+        `interfaceAttachment` (breaking OpenStack naming conventions) or the
+        resource contents would not be found.
+        """
         rid = str(uuid.uuid4().hex)
         net_id = str(uuid.uuid4().hex)
         port_id = str(uuid.uuid4().hex)
@@ -105,6 +115,11 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "compute/server/interface", port_id)
 
     def test_post_create_agent_custom_id(self):
+        """Test support for scalar IDs of objects.
+
+        The non-unique IDs are often used for administrative resources
+        not managed by users.
+        """
         agent_id = 180
         url = self.build_url('os-agents', prefix='/compute/v2.1')
         req_json = {
@@ -134,6 +149,10 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "compute/agent", str(uuid.UUID(int=agent_id)))
 
     def test_put_global_action(self):
+        """Test using HTTP method PUT for global actions.
+
+        Usually POST is used and usually actions are applied to resources.
+        """
         url = self.build_url('os-services', prefix='/compute/v2.1',
                              suffix="disable")
         request, response = self.build_api_call('PUT', url, req_json={
@@ -147,6 +166,11 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          self.service_name)
 
     def test_put_global_key(self):
+        """Test that keys can be set also globally.
+
+        The action shall be `update/set`. The target service shall
+        be qualified by name only since the ID is meaningless.
+        """
         url = self.build_url('os-services', prefix='/compute/v2.1',
                              suffix="force-down")
         request, response = self.build_api_call('PUT', url, req_json={
@@ -165,6 +189,11 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain key force-down")
 
     def test_put_key(self):
+        """Test that keys can be set on resource instances.
+
+        The resported action shall be `update/set`. The target
+        shall be specified by ID.
+        """
         url = self.build_url('servers', prefix='/compute/v2.1',
                              res_id="c489798d-8031-406d-aabb-0040a3b7b4be",
                              child_res="tags", suffix="tag-1234")
@@ -181,12 +210,14 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
 
 class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
+    """Test the neutron mappping file."""
+
     def setUp(self):
         """Set up the test.
 
         Load the mapping file and set the service name and key.
         """
-       super(NeutronAuditMappingTest, self).setUp()
+        super(NeutronAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/neutron_audit_map.yaml"
 
@@ -198,9 +229,15 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     @property
     def audit_map(self):
+        """The audit mapping filename under test."""
         return self.audit_map_file_fixture
 
     def test_get_list(self):
+        """Test the `fw` namespace-like resource.
+
+        It needs to be mapped to the same typeURI hierarchy
+        as its successor `fwaas`.
+        """
         url = self.build_url('fw', prefix='/v2.0',
                              child_res="firewalls")
         request, response = self.build_api_call('GET', url)
@@ -211,6 +248,12 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          None, self.service_name)
 
     def test_post_create_sgp(self):
+        """Test the mapping of security-group rules.
+
+        The special thing about this resource is merely
+        that it stores the *name* in the `description`
+        field.
+        """
         rid = str(uuid.uuid4().hex)
         rname = 'sgr1'
         url = self.build_url('security-group-rules', prefix='/v2.0')
@@ -222,6 +265,12 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/security-group-rule", rid, rname)
 
     def test_post_create_floatingips(self):
+        """Test mapping of floating IPs.
+
+        There is nothing special with this. This test case
+        is only special in that it uses real payloads for testing, so
+        there is a broader coverage of values.
+        """
         rid = str(uuid.uuid4().hex)
         url = self.build_url('floatingips', prefix='/v2.0')
         fip_request = {"floatingip": {
@@ -262,11 +311,10 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/floatingip", rid)
 
     def test_post_create_ports(self):
-        """regression test introduced to explain the issue with determining the
-        target project of service calls to neutron api.
+        """Regression test for determining the right target project.
 
-        The problem here was that instead of project_id, our Neutron
-        version returned tenant_id ONLY.
+        The underlying problem here was that instead of project_id,
+        our Neutron version returned tenant_id *only*.
         """
         rid = str(uuid.uuid4().hex)
         pid = str(uuid.uuid4().hex)
@@ -358,7 +406,7 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                       "attachment should contain security_groups value")
 
     def test_post_create_namespaced(self):
-        """tests the use of singleton resources for namespace prefixes."""
+        """Test the use of singleton resources for namespace prefixes."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('fwaas', prefix='/v2.0',
                              child_res="firewall_groups")
@@ -370,8 +418,7 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/firewall", target_id=rid)
 
     def test_post_create_merged_namespaced(self):
-        """check whether to namespace-like resources can be mapped to the same
-        type URI."""
+        """Test namespace-like pseudo resources mapped to the same typeURI."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('fw', prefix='/v2.0',
                              child_res="firewalls")
@@ -383,6 +430,7 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/firewall", target_id=rid)
 
     def test_get_namespaced(self):
+        """Test namespace-like pseudo resources."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('fwaas', prefix='/v2.0',
                              child_res="firewall_rules", child_res_id=rid)
@@ -394,6 +442,7 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "network/firewall/rule", target_id=rid)
 
     def test_list_namespaced(self):
+        """Test listing of resource instances beneath a namespace."""
         url = self.build_url('qos', prefix='/v2.0',
                              child_res="policies/bandwidth_limit_rules")
         request, response = self.build_api_call('GET', url)
@@ -404,6 +453,7 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                          self.service_name)
 
     def test_post_create_multiple(self):
+        """Test buld creation of resource instances."""
         items = [{'id': str(uuid.uuid4().hex), 'name': 'name-' + str(i)} for
                  i in range(3)]
 
@@ -423,20 +473,16 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
                              "network/network",
                              items[idx]['id'], items[idx]['name'])
 
-    def test_put_custom_action(self):
-        """"/v2.0/routers/0e7a2b1b-1b1a-428b-97b5-afd1a41c8f74.
-
-        /remove_router_interface"
-        """
-
 
 class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):
+    """Test the cinder mappping file."""
+
     def setUp(self):
-         """Set up the test.
+        """Set up the test.
 
         Load the mapping file and set the service name and key.
         """
-       super(CinderAuditMappingTest, self).setUp()
+        super(CinderAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/cinder_audit_map.yaml"
 
@@ -448,9 +494,11 @@ class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     @property
     def audit_map(self):
+        """The audit mapping filename under test."""
         return self.audit_map_file_fixture
 
     def test_post_create_child(self):
+        """Test creating a child resource with POST."""
         rid = str(uuid.uuid4().hex)
         child_rid = str(uuid.uuid4().hex)
         url = self.build_url('types', prefix='/v3/' + self.project_id,
@@ -471,6 +519,7 @@ class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):
                          target_id=child_rid)
 
     def test_get_custom_list_action(self):
+        """Test using a custom action for reading lists."""
         rid = str(uuid.uuid4().hex)
         url = self.build_url('types', prefix='/v3/' + self.project_id,
                              res_id=rid, suffix="os-volume-type-access")
@@ -483,7 +532,13 @@ class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):
 
 
 class ManilaAuditMappingTest(base.BaseAuditMiddlewareTest):
+    """Test the manila mappping file."""
+
     def setUp(self):
+        """Set up the test.
+
+        Load the mapping file and set the service name and key.
+        """
         super(ManilaAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/manila_audit_map.yaml"
@@ -496,9 +551,14 @@ class ManilaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     @property
     def audit_map(self):
+        """The audit mapping filename under test."""
         return self.audit_map_file_fixture
 
     def test_get_list_shares(self):
+        """Test listing resource instances.
+
+        This is just a arbitary smoke-test for Manila.
+        """
         url = self.build_url('shares', prefix='/v2/' + self.project_id)
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -509,12 +569,14 @@ class ManilaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
 
 class DesignateAuditMappingTest(base.BaseAuditMiddlewareTest):
+    """Test the designate mappping file."""
+
     def setUp(self):
         """Set up the test.
 
         Load the mapping file and set the service name and key.
         """
-       super(DesignateAuditMappingTest, self).setUp()
+        super(DesignateAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/designate_audit_map.yaml"
 
@@ -526,9 +588,14 @@ class DesignateAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     @property
     def audit_map(self):
+        """The audit mapping filename under test."""
         return self.audit_map_file_fixture
 
     def test_get_list_zones(self):
+        """Test a list action.
+
+        This is just an arbitary smoketest.
+        """
         url = self.build_url('zones', prefix='/v2')
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -1,15 +1,37 @@
-import json
-import os
-import uuid
-from builtins import str
+#    Licensed under the Apache License, Version 2.0 (the "License"); you may
+#    not use this file except in compliance with the License. You may obtain
+#    a copy of the License at
+#
+#         http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS, WITHOUT
+#    WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+#    License for the specific language governing permissions and limitations
+#    under the License.
 
-from pycadf import cadftaxonomy as taxonomy
+"""Smoke tests for our mapping files.
+
+These tests cover all the ugly corner-cases that arose when
+elaborating the mappings from the API documentation.
+"""
 
 from auditmiddleware.tests.unit import base
+from builtins import str
+import json
+import os
+from pycadf import cadftaxonomy as taxonomy
+import uuid
 
 
 class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
+    """Test the nova mappping file."""
+
     def setUp(self):
+        """Set up the test.
+
+        Load the mapping file and set the service name and key.
+        """
         super(NovaAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/nova_audit_map.yaml"
@@ -22,9 +44,11 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
     @property
     def audit_map(self):
+        """audit_map attribute."""
         return self.audit_map_file_fixture
 
     def test_get_list(self):
+        """Test listing a resource (GET w/o object ID)."""
         url = self.build_url('servers', prefix='/compute/v2.1')
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -34,6 +58,7 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          None, self.service_name)
 
     def test_get_list_os_migrations(self):
+        """Test resource names in the URL path can be renamed.""" 
         url = self.build_url('os-migrations', prefix='/compute/v2.1')
         request, response = self.build_api_call('GET', url)
         event = self.build_event(request, response)
@@ -42,9 +67,15 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
                          "compute/migrations",
                          None, self.service_name)
 
-    # ensure that the os-prefix is omitted when deriving JSON type name from
-    # the api_name
     def test_get_read(self):
+        """Test that the os-prefix in the path is omitted.
+        
+        When deriving the name of the attribute containing
+        the resource contents (JSON type name) from the
+        path segment representing the resource (API name),
+        any 'os-' prefix needs to be omitted.
+        """
+    # the api_name
         rid = str(uuid.uuid4().hex)
         url = self.build_url('os-hypervisors', prefix='/compute/v2.1',
                              res_id=rid)
@@ -151,7 +182,11 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
 class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
     def setUp(self):
-        super(NeutronAuditMappingTest, self).setUp()
+        """Set up the test.
+
+        Load the mapping file and set the service name and key.
+        """
+       super(NeutronAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/neutron_audit_map.yaml"
 
@@ -397,7 +432,11 @@ class NeutronAuditMappingTest(base.BaseAuditMiddlewareTest):
 
 class CinderAuditMappingTest(base.BaseAuditMiddlewareTest):
     def setUp(self):
-        super(CinderAuditMappingTest, self).setUp()
+         """Set up the test.
+
+        Load the mapping file and set the service name and key.
+        """
+       super(CinderAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/cinder_audit_map.yaml"
 
@@ -471,7 +510,11 @@ class ManilaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
 class DesignateAuditMappingTest(base.BaseAuditMiddlewareTest):
     def setUp(self):
-        super(DesignateAuditMappingTest, self).setUp()
+        """Set up the test.
+
+        Load the mapping file and set the service name and key.
+        """
+       super(DesignateAuditMappingTest, self).setUp()
 
         self.audit_map_file_fixture = "etc/designate_audit_map.yaml"
 

--- a/auditmiddleware/tests/unit/test_mappings.py
+++ b/auditmiddleware/tests/unit/test_mappings.py
@@ -78,21 +78,21 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
         url = self.build_url('os-agents', prefix='/compute/v2.1')
         req_json = {
             u'agent': {
-                u'architecture': u'tempest-x86_64-831697749', 
-                u'hypervisor': u'common', 
-                u'md5hash': u'add6bb58e139be103324d04d82d8f545', 
-                u'os': u'linux', 
-                u'url': u'xxx://xxxx/xxx/xxx', 
+                u'architecture': u'tempest-x86_64-831697749',
+                u'hypervisor': u'common',
+                u'md5hash': u'add6bb58e139be103324d04d82d8f545',
+                u'os': u'linux',
+                u'url': u'xxx://xxxx/xxx/xxx',
                 u'version': u'7.0'
             }
         }
         resp_json = {
-            u'agent_id': agent_id, 
-            u'architecture': u'tempest-x86_64-831697749', 
-            u'hypervisor': u'common', 
-            u'md5hash': u'add6bb58e139be103324d04d82d8f545', 
-            u'os': u'linux', 
-            u'url': u'xxx://xxxx/xxx/xxx', 
+            u'agent_id': agent_id,
+            u'architecture': u'tempest-x86_64-831697749',
+            u'hypervisor': u'common',
+            u'md5hash': u'add6bb58e139be103324d04d82d8f545',
+            u'os': u'linux',
+            u'url': u'xxx://xxxx/xxx/xxx',
             u'version': u'7.0'
         }
         request, response = self.build_api_call(
@@ -101,7 +101,7 @@ class NovaAuditMappingTest(base.BaseAuditMiddlewareTest):
 
         self.check_event(request, response, event, taxonomy.ACTION_CREATE,
                          "compute/agent", str(uuid.UUID(int=agent_id)))
-     
+
     def test_put_global_action(self):
         url = self.build_url('os-services', prefix='/compute/v2.1',
                              suffix="disable")

--- a/auditmiddleware/tests/unit/utils.py
+++ b/auditmiddleware/tests/unit/utils.py
@@ -127,8 +127,8 @@ class TestResponse(requests.Response):
     def __eq__(self, other):
         """Test if the response is equivalent to another response.
 
-        This works by comparing the attribute dictionaries of both TestResponse
-        instances.
+        This works by comparing the attribute dictionaries of both
+        TestResponse instances.
         """
         return self.__dict__ == other.__dict__
 

--- a/auditmiddleware/tests/unit/utils.py
+++ b/auditmiddleware/tests/unit/utils.py
@@ -10,23 +10,22 @@
 #    License for the specific language governing permissions and limitations
 #    under the License.
 
-import sys
-import time
-import uuid
-import warnings
+"""Common classes and utils for the tests."""
 
 import fixtures
-import mock
+from oslo_log import log as logging
 import oslotest.base as oslotest
-import requests
+import warnings
 import webob
 import webtest
-from oslo_log import log as logging
 
 
-class BaseTestCase(oslotest.BaseTestCase):
+class MiddlewareTestCase(oslotest.BaseTestCase):
+    """Base class for all test-cases."""
+
     def setUp(self):
-        super(BaseTestCase, self).setUp()
+        """Set up the test."""
+        super(MiddlewareTestCase, self).setUp()
 
         # If auditmiddleware calls any deprecated function this will raise
         # an exception.
@@ -36,52 +35,8 @@ class BaseTestCase(oslotest.BaseTestCase):
 
         self.logger = self.useFixture(fixtures.FakeLogger(level=logging.DEBUG))
 
-
-class TestCase(BaseTestCase):
-    TEST_DOMAIN_ID = '1'
-    TEST_DOMAIN_NAME = 'aDomain'
-    TEST_GROUP_ID = uuid.uuid4().hex
-    TEST_ROLE_ID = uuid.uuid4().hex
-    TEST_TENANT_ID = '1'
-    TEST_TENANT_NAME = 'aTenant'
-    TEST_TOKEN = 'aToken'
-    TEST_TRUST_ID = 'aTrust'
-    TEST_USER = 'test'
-    TEST_USER_ID = uuid.uuid4().hex
-
-    TEST_ROOT_URL = 'http://127.0.0.1:5000/'
-
-    def setUp(self):
-        super(TestCase, self).setUp()
-        self.time_patcher = mock.patch.object(time, 'time', lambda: 1234)
-        self.time_patcher.start()
-
-    def tearDown(self):
-        self.time_patcher.stop()
-        super(TestCase, self).tearDown()
-
-
-if tuple(sys.version_info)[0:2] < (2, 7):
-
-    def assertDictEqual(self, d1, d2, msg=None):
-        # Simple version taken from 2.7
-        self.assertIsInstance(d1, dict,
-                              'First argument is not a dictionary')
-        self.assertIsInstance(d2, dict,
-                              'Second argument is not a dictionary')
-        if d1 != d2:
-            if msg:
-                self.fail(msg)
-            else:
-                standardMsg = '%r != %r' % (d1, d2)
-                self.fail(standardMsg)
-
-    TestCase.assertDictEqual = assertDictEqual
-
-
-class MiddlewareTestCase(BaseTestCase):
-
     def create_middleware(self, cb, **kwargs):
+        """Create a middleware (abstract method to be redefined)."""
         raise NotImplementedError("implement this in your tests")
 
     def create_simple_middleware(self,
@@ -89,6 +44,14 @@ class MiddlewareTestCase(BaseTestCase):
                                  body='',
                                  headers=None,
                                  **kwargs):
+        """Create a simple middleware with fixed responses.
+
+        Parameters:
+            status: HTTP status code to respond with (e.g. '200 OK')
+            body: payload of the response
+            headers: header fields of the response
+            kwargs: custom parameters to be forwarded to create_middleware
+        """
         def cb(req):
             resp = webob.Response(body, status)
             resp.headers.update(headers or {})
@@ -97,87 +60,12 @@ class MiddlewareTestCase(BaseTestCase):
         return self.create_middleware(cb, **kwargs)
 
     def create_app(self, *args, **kwargs):
+        """Create a new app using create_middleware."""
         return webtest.TestApp(self.create_middleware(*args, **kwargs))
 
     def create_simple_app(self, *args, **kwargs):
-        return webtest.TestApp(self.create_simple_middleware(*args, **kwargs))
+        """Create a new app using the create_simple_middleware.
 
-
-class TestResponse(requests.Response):
-    """Utility class to wrap requests.Response.
-
-    Class used to wrap requests.Response and provide some convenience to
-    initialize with a dict.
-    """
-
-    def __init__(self, data):
-        self._text = None
-        super(TestResponse, self).__init__()
-        if isinstance(data, dict):
-            self.status_code = data.get('status_code', 200)
-            headers = data.get('headers')
-            if headers:
-                self.headers.update(headers)
-            # Fake the text attribute to streamline Response creation
-            # _content is defined by requests.Response
-            self._content = data.get('text')
-        else:
-            self.status_code = data
-
-    def __eq__(self, other):
-        """Test if the response is equivalent to another response.
-
-        This works by comparing the attribute dictionaries of both
-        TestResponse instances.
+        Arguments are forwarded to create_simple_middleware.
         """
-        return self.__dict__ == other.__dict__
-
-    @property
-    def text(self):
-        return self.content
-
-
-class DisableModuleFixture(fixtures.Fixture):
-    """A fixture to provide support for unloading/disabling modules."""
-
-    def __init__(self, module, *args, **kw):
-        super(DisableModuleFixture, self).__init__(*args, **kw)
-        self.module = module
-        self._finders = []
-        self._cleared_modules = {}
-        self.addCleanup(self._tearDown)
-
-    def _tearDown(self):
-        for finder in self._finders:
-            sys.meta_path.remove(finder)
-        sys.modules.update(self._cleared_modules)
-
-    def clear_module(self):
-        cleared_modules = {}
-        for fullname in list(sys.modules.keys()):
-            if (fullname == self.module
-                    or fullname.startswith(self.module + '.')):
-                cleared_modules[fullname] = sys.modules.pop(fullname)
-        return cleared_modules
-
-    def setUp(self):
-        """Ensure ImportError for the specified module."""
-        super(DisableModuleFixture, self).setUp()
-
-        # Clear 'module' references in sys.modules
-        self._cleared_modules.update(self.clear_module())
-
-        finder = NoModuleFinder(self.module)
-        self._finders.append(finder)
-        sys.meta_path.insert(0, finder)
-
-
-class NoModuleFinder(object):
-    """Disallow further imports of 'module'."""
-
-    def __init__(self, module):
-        self.module = module
-
-    def find_module(self, fullname, path):
-        if fullname == self.module or fullname.startswith(self.module + '.'):
-            raise ImportError
+        return webtest.TestApp(self.create_simple_middleware(*args, **kwargs))

--- a/etc/nova_audit_map.yaml
+++ b/etc/nova_audit_map.yaml
@@ -55,6 +55,7 @@ resources:
         custom_id: name
     migrations:
     migrations_legacy_api:
+        # here is an example how to map distinct API paths to the same resource type
         api_name: os-migrations
         type_uri: compute/migrations
     os-server-external-events:
@@ -79,6 +80,7 @@ resources:
     servers:
         payloads:
             exclude:
+              # will not be part of event nor be DEBUG logged
               - adminPass
         custom_actions:
             # server actions

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -3,20 +3,19 @@
 # process, which may cause wedges in the gate later.
 
 datadog
-hacking<0.11,>=0.10.0
-flake8-docstrings==0.2.1.post1 # MIT
+hacking>=1.1.0,<1.2.0 # Apache-2.0
 
 coverage!=4.4,>=4.0 # Apache-2.0
-cryptography>=2.1 # BSD/Apache-2.0
+#cryptography>=2.1 # BSD/Apache-2.0
 fixtures>=3.0.0 # Apache-2.0/BSD
-mock>=2.0.0 # BSD
-oslotest>=3.2.0 # Apache-2.0
+mock>=3.0.0 # BSD
+oslotest>=3.8.0 # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
-stevedore>=1.20.0 # Apache-2.0
+#stevedore>=1.20.0 # Apache-2.0
 stestr>=2.0.0  # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
-python-memcached>=1.59 # PSF
+#python-memcached>=1.59 # PSF
 WebTest>=2.0.27 # MIT
 oslo.messaging>=5.29.0 # Apache-2.0
 

--- a/tox.ini
+++ b/tox.ini
@@ -17,7 +17,7 @@ commands = stestr run {posargs}
 [testenv:pep8]
 basepython = python3
 commands =
-  flake8
+  flake8 {posargs}
   bandit -r auditmiddleware -x tests -n5
 
 [testenv:bandit]
@@ -70,8 +70,6 @@ ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,H405,W504,E731
 exclude =  .venv,.git,.tox,dist,*lib/python*,*egg,build,tools/xenserver*,releasenotes
 # To get a list of functions that are more complex than 25, set max-complexity
 # to 25 and run 'tox -epep8'.
-# 39 is currently the most complex thing we have
-# TODO(jogo): get this number down to 25 or so
 max-complexity=25
 
 [testenv:docs]

--- a/tox.ini
+++ b/tox.ini
@@ -47,15 +47,32 @@ basepython = python3
 commands = oslo_debug_helper -t auditmiddleware/tests {posargs}
 
 [flake8]
-# D100: Missing docstring in public module
-# D101: Missing docstring in public class
-# D102: Missing docstring in public method
-# D103: Missing docstring in public function
-# D104: Missing docstring in public package
-# D203: 1 blank line required before class docstring (deprecated in pep257)
-ignore = D100,D101,D102,D103,D104,D203
-show-source = True
-exclude = .venv,.tox,dist,doc,*egg,build
+# E125 is deliberately excluded. See
+# https://github.com/jcrocholl/pep8/issues/126. It's just wrong.
+#
+# Most of the whitespace related rules (E12* and E131) are excluded
+# because while they are often useful guidelines, strict adherence to
+# them ends up causing some really odd code formatting and forced
+# extra line breaks. Updating code to enforce these will be a hard sell.
+#
+# H405 is another one that is good as a guideline, but sometimes
+# multiline doc strings just don't have a natural summary
+# line. Rejecting code for this reason is wrong.
+#
+# E251 Skipped due to https://github.com/jcrocholl/pep8/issues/301
+#
+# W504 skipped since you must choose either W503 or W504 (they conflict)
+#
+# E731 temporarily skipped because of the number of
+# these that have to be fixed
+enable-extensions = H106,H203,H904
+ignore = E121,E122,E123,E124,E125,E126,E127,E128,E129,E131,E251,H405,W504,E731
+exclude =  .venv,.git,.tox,dist,*lib/python*,*egg,build,tools/xenserver*,releasenotes
+# To get a list of functions that are more complex than 25, set max-complexity
+# to 25 and run 'tox -epep8'.
+# 39 is currently the most complex thing we have
+# TODO(jogo): get this number down to 25 or so
+max-complexity=25
 
 [testenv:docs]
 basepython = python3


### PR DESCRIPTION
The current implementation of attach_payload method removes sensitive information not just from the CADF event but also from the request payload dictionary passed as an input parameter.
  
Fortunately the webob request json property is implemented so inefficiently that it parses the request body and builds a new dictionary every time the property is read. This is to our rescue because otherwise our request would be damaged by attach_payload. It isn't so there should not be issues at runtime. Still this issue needs to be fixed since the webob behaviour is not guaranteed and any future change becomes more risky because of this.

I'll use the opportunity to fix the plethora of pep8 warnings, also adding documentation to many many places.