### PR TITLE
fixing inherited keystonemiddleware bug 1809101

### DIFF
--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -139,7 +139,8 @@ class AuditMiddleware(object):
             # currently there is nothing useful in the context
             request.environ['audit.context'] = {}
             for e in events:
-                self._notifier.notify(request.environ['audit.context'], e.as_dict())
+                ctx = request.environ['audit.context']
+                self._notifier.notify(ctx, e.as_dict())
 
     @webob.dec.wsgify
     def __call__(self, req):
@@ -150,7 +151,8 @@ class AuditMiddleware(object):
         # Cannot use a RequestClass on wsgify above because the `req` object is
         # a `WebOb.Request` when this method is called so the RequestClass is
         # ignored by the wsgify wrapper.
-        req.environ['audit.context'] = oslo_context.get_admin_context().to_dict()
+        ctx = oslo_context.get_admin_context().to_dict()
+        req.environ['audit.context'] = ctx
 
         try:
             response = req.get_response(self._application)

--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -137,9 +137,9 @@ class AuditMiddleware(object):
 
         if events:
             # currently there is nothing useful in the context
-            context = {}
+            request.environ['audit.context'] = {}
             for e in events:
-                self._notifier.notify(context, e.as_dict())
+                self._notifier.notify(request.environ['audit.context'], e.as_dict())
 
     @webob.dec.wsgify
     def __call__(self, req):
@@ -150,7 +150,7 @@ class AuditMiddleware(object):
         # Cannot use a RequestClass on wsgify above because the `req` object is
         # a `WebOb.Request` when this method is called so the RequestClass is
         # ignored by the wsgify wrapper.
-        req.context = oslo_context.get_admin_context().to_dict()
+        req.environ['audit.context'] = oslo_context.get_admin_context().to_dict()
 
         try:
             response = req.get_response(self._application)

--- a/auditmiddleware/tests/unit/test_audit_middleware.py
+++ b/auditmiddleware/tests/unit/test_audit_middleware.py
@@ -91,7 +91,7 @@ class AuditMiddlewareTest(base.BaseAuditMiddlewareTest):
 
         req = webob.Request.blank(path,
                                   environ=self.get_environ_header('GET'))
-        req.context = {}
+        req.environ['audit.context'] = {}
 
         middleware = self.create_simple_middleware()
         middleware._process_request(req, webob.response.Response())
@@ -139,7 +139,7 @@ class AuditMiddlewareTest(base.BaseAuditMiddlewareTest):
 
         req = webob.Request.blank(path,
                                   environ=self.get_environ_header('GET'))
-        req.context = {}
+        req.environ['audit.context']= {}
         self.notifier.notify.side_effect = Exception('error')
 
         middleware(req)
@@ -164,7 +164,7 @@ class AuditMiddlewareTest(base.BaseAuditMiddlewareTest):
         req = webob.Request.blank(url,
                                   environ=self.get_environ_header('GET'),
                                   remote_addr='192.168.0.1')
-        req.context = {}
+        req.environ['audit.context'] = {}
         middleware._process_request(req)
         payload = self.notifier.notify.call_args_list[0][0][1]
         self.assertEqual(payload['outcome'], 'unknown')

--- a/auditmiddleware/tests/unit/test_audit_middleware.py
+++ b/auditmiddleware/tests/unit/test_audit_middleware.py
@@ -139,7 +139,7 @@ class AuditMiddlewareTest(base.BaseAuditMiddlewareTest):
 
         req = webob.Request.blank(path,
                                   environ=self.get_environ_header('GET'))
-        req.environ['audit.context']= {}
+        req.environ['audit.context'] = {}
         self.notifier.notify.side_effect = Exception('error')
 
         middleware(req)

--- a/lower-constraints.txt
+++ b/lower-constraints.txt
@@ -23,7 +23,7 @@ GitPython==2.1.8
 hacking==0.10.0
 idna==2.6
 iso8601==0.1.12
-keystoneauth1==3.4.0
+keystoneauth1==3.12.0
 linecache2==1.0.0
 mccabe==0.2.1
 mock==2.0.0
@@ -57,7 +57,7 @@ pyinotify==0.9.6
 pyparsing==2.2.0
 pyperclip==1.6.0
 python-dateutil==2.7.0
-python-keystoneclient==3.10.0
+python-keystoneclient==3.20.0
 python-memcached==1.59
 python-mimeparse==1.6.0
 python-subunit==1.2.0


### PR DESCRIPTION
Our auditmiddleware breaks downstream request processing by Glance because it replaces the request context with its own dictionary. Recent glance versions makes stricter assumptions on the request context's type which are not met by our own context.

Since this part of the code was copied from the original keystonemiddleware unchanged, we can also apply their fix.

Conclusions: Replacing parts of objects we do not own is a bad idea. 