### PR TITLE
Don't read JSON from request of non application/json content-type

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -381,7 +381,8 @@ class OpenStackAuditMiddleware(object):
                 # which contains a list of items
                 res_pl = res_payload[res_spec.type_name]
                 req_pl = None
-                if self._payloads_enabled and res_spec.payloads['enabled']:
+                if self._payloads_enabled and res_spec.payloads['enabled'] \
+                        and request.content_type == 'application/json':
                     req_pl = iter(request.json.get(res_spec.type_name))
 
                 # create one event per item
@@ -435,7 +436,8 @@ class OpenStackAuditMiddleware(object):
 
             if event and request.method[0] == 'P' \
                     and self._payloads_enabled \
-                    and res_spec.payloads['enabled']:
+                    and res_spec.payloads['enabled'] \
+                    and request.content_type == 'application/json':
                 self._attach_payload(event, request.json, res_spec)
 
             events = [event]


### PR DESCRIPTION
Some parts of the code already guard against this, but some don't. This
leads to a problem in glance, where accessing `request.json` on a failed
image-upload (with content-type "application/octet-stream") can lead to
the auditmiddleware downloading the whole image body, which - for glance
- automatically ends up in a temporary file, because that's how the
WebOb library used by glance handles big WSGI request bodies.

We now only read `request.json` if the request has the appropriate
content-type.

An alternative would be to prohibit reading `request.json` if the
content-type is "application/octet-stream", but I'm not sure if we have
broken services out there, that support JSON in non-json requests.