### PR TITLE
setup.cfg: Replace dashes with underscores

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,11 +1,11 @@
 [metadata]
 name = audit-middleware
 summary = Audit Middleware for OpenStack
-description-file =
+description_file =
     README.md
 author = SAP SE
-author-email = joachim.barheine@sap.com
-home-page = https://github.com/sapcc/openstack-audit-middleware
+author_email = nathan.oyler@sap.com
+home_page = https://github.com/sapcc/openstack-audit-middleware
 classifier =
     Development Status :: 4 - Beta
     Environment :: OpenStack
@@ -28,7 +28,7 @@ audit_notifications =
   oslo.messaging!=5.25.0,>=5.24.2 # Apache-2.0
 
 [global]
-setup-hooks =
+setup_hooks =
     pbr.hooks.setup_hook
 
 [entry_points]


### PR DESCRIPTION
Since setuptools v54.1.0, the parmeters with dash have been deprecated in favor of the new parameters with underscore.

This change updates the parameters accordingly to avoid the warnings like the example below.

  UserWarning: Usage of dash-separated 'description-file' will not be
  supported in future versions. Please use the underscore name
  'description_file' instead

https://github.com/pypa/setuptools/commit/a2e9ae4cb