### PR TITLE
Add backup project_id in case of none for Neutron

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -488,6 +488,16 @@ class OpenStackAuditMiddleware(object):
             return None
 
         project_id = request.environ.get('HTTP_X_PROJECT_ID')
+        # If project_id is undefined, look for another variable. This is 
+        # added specific to catching delete events from Neutron
+        if project_id is None:
+            context = request.environ['webob.adhoc_attrs'].get('context', {})
+            original_resources = context.get('original_resources', [])
+            if original_resources and isinstance(original_resources, list):
+                first_resource = original_resources[0]
+                if isinstance(first_resource, dict):
+                    project_id = first_resource.get('project_id')
+
         domain_id = request.environ.get('HTTP_X_DOMAIN_ID')
         application_credential_id = None
         token_info = request.environ.get('keystone.token_info')

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -491,7 +491,8 @@ class OpenStackAuditMiddleware(object):
         # If project_id is undefined, look for another variable. This is 
         # added specific to catching delete events from Neutron
         if project_id is None:
-            context = request.environ['webob.adhoc_attrs'].get('context', {})
+            adhoc_attrs = request.environ.get('webob.adhoc_attrs', {})
+            context = adhoc_attrs.get('context', {})
             original_resources = context.get('original_resources', [])
             if original_resources and isinstance(original_resources, list):
                 first_resource = original_resources[0]

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -488,7 +488,7 @@ class OpenStackAuditMiddleware(object):
             return None
 
         project_id = request.environ.get('HTTP_X_PROJECT_ID')
-        # If project_id is undefined, look for another variable. This is 
+        # If project_id is undefined, look for another variable. This is
         # added specific to catching delete events from Neutron
         if project_id is None:
             adhoc_attrs = request.environ.get('webob.adhoc_attrs', {})


### PR DESCRIPTION
This is intended to catch delete events that don't have project_id as part of their req. 