### PR TITLE
add debug logging to request_id and global_request_id

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -513,6 +513,9 @@ class OpenStackAuditMiddleware(object):
             if application_credential:
                 application_credential_id = application_credential['id']
 
+        self.LOG.debug("Request ID: %s", request.environ.get('openstack.request_id'))
+        self.LOG.debug("Global Request ID: %s", request.environ.get('openstack.global_request_id'))
+
         initiator = OpenStackResource(
             project_id=project_id, domain_id=domain_id,
             application_credential_id=application_credential_id,


### PR DESCRIPTION
I am not sure why this isn't functioning, adding debug logging to validate I'm getting the variables. I do see them in the context for Neutron we listed in the past, so it all seems like it should be working in my view. 