### PR TITLE
Add option to disable using oslo_message notifier

### DIFF
--- a/auditmiddleware/__init__.py
+++ b/auditmiddleware/__init__.py
@@ -34,6 +34,13 @@ _LOG = None
 AUDIT_MIDDLEWARE_GROUP = 'audit_middleware_notifications'
 
 _AUDIT_OPTS = [
+    cfg.BoolOpt('use_oslo_messaging',
+                default=True,
+                help='Indicate whether to use oslo_messaging as the notifier. '
+                     'If set to False, the local logger will be used as the '
+                     'notifier. If set to True, the oslo_messaging package '
+                     'must also be present. Otherwise, the local will be used '
+                     'instead.'),
     cfg.StrOpt('driver',
                help='The Driver to handle sending notifications. Possible '
                     'values are messaging, messagingv2, routing, log, test, '

--- a/auditmiddleware/_notifier.py
+++ b/auditmiddleware/_notifier.py
@@ -160,7 +160,7 @@ class _MessagingNotifier(Thread):
 
 def create_notifier(conf, log, metrics_enabled):
     """Create a new notifier."""
-    if oslo_messaging:
+    if oslo_messaging and conf.get('use_oslo_messaging'):
         transport = oslo_messaging.get_notification_transport(
             conf,
             url=conf.audit_middleware_notifications.transport_url)

--- a/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
+++ b/auditmiddleware/tests/unit/test_audit_oslo_messaging.py
@@ -151,3 +151,13 @@ class AuditNotifierConfigTest(base.BaseAuditMiddlewareTest):
         self.assertTrue(m.called)
         # make sure first call kwarg 'url' is same as provided transport_url
         self.assertEqual(transport_url, m.call_args_list[0][1]['url'])
+
+    def test_do_not_use_oslo_messaging(self):
+        self.cfg.config(use_oslo_messaging=False,
+                        group='audit_middleware_notifications')
+        audit_middleware = self.create_simple_middleware()
+
+        # make sure it is using a local notifier instead of oslo_messaging
+        self.assertTrue(
+            isinstance(audit_middleware._notifier,
+                       audit._notifier._LogNotifier))


### PR DESCRIPTION
Add a configuration option, 'use_oslo_messaging', to indicate whether
to use oslo_messaging notifier. It is set to true for backwards
compatibility.

We can't use audit middleware with services like Swift, which have no
dependency on Oslo and does not work well with oslo_log. Swift uses rsyslog.
Currently, audit middleware chooses oslo_messaging if the
package is installed. This is problematic if Swift proxy is on the same
controller as any service which consumes oslo_messaging. With this new option,
Swift can now safely consume audit middleware by electing to use local
log notifier instead of oslo_messaging.