### PR TITLE
Fix access scope of use_oslo_messaging

### DIFF
--- a/auditmiddleware/_notifier.py
+++ b/auditmiddleware/_notifier.py
@@ -160,7 +160,7 @@ class _MessagingNotifier(Thread):
 
 def create_notifier(conf, log, metrics_enabled):
     """Create a new notifier."""
-    if oslo_messaging and conf.get('use_oslo_messaging'):
+    if oslo_messaging and conf.audit_middleware_notifications.get('use_oslo_messaging'):
         transport = oslo_messaging.get_notification_transport(
             conf,
             url=conf.audit_middleware_notifications.transport_url)


### PR DESCRIPTION
the conf object is in the DEFAULT scope,
so we need to access first audit_middleware_notifications on it