### PR TITLE
Handle requests with no content length

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -382,7 +382,7 @@ class OpenStackAuditMiddleware(object):
 
         # Check if the response has a JSON body
         has_json_body = (response and
-            response.content_length > 0 and
+            (response.content_length or 0) > 0 and
             response.text and  # Check if response body is not empty
             response.content_type == "application/json")
 


### PR DESCRIPTION
Some requests (like DELETE) have a content_length of None in their response. As trying to compare None with an integer raises an exception we need to make sure we have an int to compare to.

Without this patch a DELETE will trigger the following exception:

TypeError: '>' not supported between instances of 'NoneType' and 'int'