### PR TITLE
add defensive check for none token for read events

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -365,6 +365,16 @@ class OpenStackAuditMiddleware(object):
         information to understand what happened. This allows for
         incremental improvement.
         """
+        # Defensive check for None token
+        if token is None:
+            self._log.warning("unknown resource: None (created on demand)")
+            res_name = 'unknown'
+            res_dict = {'api_name': 'unknown'}
+            sub_res_spec, _ = self._build_res_spec(res_name,
+                                                parent_type_uri,
+                                                res_dict)
+            return sub_res_spec
+
         self._log.warning("unknown resource: %s (created on demand)",
                           token)
         res_name = token.replace('_', '-')

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,11 +3,11 @@
 # process, which may cause wedges in the gate later.
 
 # datadog (soft dependency)
-keystoneauth1>=3.4.0 # Apache-2.0
+keystoneauth1>=5.8.0 # Apache-2.0
 oslo.messaging
-oslo.config>=5.2.0 # Apache-2.0
-oslo.serialization!=2.19.1,>=2.18.0 # Apache-2.0
-pycadf!=2.0.0,>=1.1.0 # Apache-2.0
+oslo.config>=9.6.0 # Apache-2.0
+oslo.serialization>=5.5.0 # Apache-2.0
+pycadf>=3.1.1 # Apache-2.0
 PyYAML
-requests>=2.14.2 # Apache-2.0
-WebOb>=1.7.1 # MIT
+requests>=2.32.3 # Apache-2.0
+WebOb>=1.8.9 # MIT

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@ mock>=3.0.0 # BSD
 oslotest>=3.8.0 # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
 #stevedore>=1.20.0 # Apache-2.0
-stestr>=2.0.0  # Apache-2.0
+stestr==3.2.1  # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 #python-memcached>=1.59 # PSF

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -6,19 +6,19 @@ datadog==0.50.1 # 0.31.0 causing test errors
 hacking>=7.0.0,<7.1.0 # Apache-2.0 # hacking==6.0.1 relies on py3.8 # Apache-2.0
 flake8-docstrings~=1.7.0 # MIT
 
-coverage!=4.4,>=4.0 # Apache-2.0
+coverage>=7.0.0 # Apache-2.0
 #cryptography>=2.1 # BSD/Apache-2.0
-fixtures>=3.0.0 # Apache-2.0/BSD
-mock>=3.0.0 # BSD
-oslotest>=3.8.0 # Apache-2.0
-requests-mock>=1.2.0 # Apache-2.0
+fixtures>=4.1.0 # Apache-2.0/BSD
+mock>=5.1.0 # BSD
+oslotest>=5.0.0 # Apache-2.0
+requests-mock>=1.12.1 # Apache-2.0
 #stevedore>=1.20.0 # Apache-2.0
-stestr>=2.0.0  # Apache-2.0
-testresources>=2.0.0 # Apache-2.0/BSD
-testtools>=2.2.0 # MIT
+stestr>=4.1.0  # Apache-2.0
+testresources>=2.0.1 # Apache-2.0/BSD
+testtools>=2.7.2 # MIT
 #python-memcached>=1.59 # PSF
-WebTest>=2.0.27 # MIT
-oslo.messaging>=5.29.0 # Apache-2.0
+WebTest>=3.0.1 # MIT
+oslo.messaging>=14.9.1 # Apache-2.0
 
 # Bandit security code scanner
-bandit>=1.1.0 # Apache-2.0
+bandit>=1.7.10 # Apache-2.0

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,3 +22,5 @@ oslo.messaging>=5.29.0 # Apache-2.0
 
 # Bandit security code scanner
 bandit>=1.1.0 # Apache-2.0
+
+voluptuous>=0.15.2 # MIT

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@ mock>=3.0.0 # BSD
 oslotest>=3.8.0 # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
 #stevedore>=1.20.0 # Apache-2.0
-stestr===4.1.0  # Apache-2.0
+stestr>=2.0.0  # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 #python-memcached>=1.59 # PSF

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -13,7 +13,7 @@ mock>=3.0.0 # BSD
 oslotest>=3.8.0 # Apache-2.0
 requests-mock>=1.2.0 # Apache-2.0
 #stevedore>=1.20.0 # Apache-2.0
-stestr==3.2.1  # Apache-2.0
+stestr===4.1.0  # Apache-2.0
 testresources>=2.0.0 # Apache-2.0/BSD
 testtools>=2.2.0 # MIT
 #python-memcached>=1.59 # PSF

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -22,5 +22,3 @@ oslo.messaging>=5.29.0 # Apache-2.0
 
 # Bandit security code scanner
 bandit>=1.1.0 # Apache-2.0
-
-voluptuous>=0.15.2 # MIT

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv = VIRTUAL_ENV={envdir}
          OS_STDOUT_NOCAPTURE=False
          OS_STDERR_NOCAPTURE=False
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt}
+    #-c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}


### PR DESCRIPTION
Due to us adding read events to barbican, read events on either

Unmapped endpoints 
and 
root endpoints

give an error when it can't compare the token when it's none. This will allow it to continue and pass the event along while giving us information to understand how to correct the problem. 

For the specific unmapped endpoint (versions) I have a PR to add it to the audit map, but this will also help root calls. 