### PR TITLE
Fix project_id handling for RequestContext objects

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -531,8 +531,8 @@ class OpenStackAuditMiddleware(object):
             # Get the context - could be dict or RequestContext object
             context = adhoc_attrs.get('context', {})
 
-            original_resources = []
             # Handle both dict and RequestContext object types
+            original_resources = []
             if hasattr(context, 'original_resources'):
                 original_resources = context.original_resources
             else:

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -529,14 +529,14 @@ class OpenStackAuditMiddleware(object):
             adhoc_attrs = request.environ.get('webob.adhoc_attrs', {})
 
             # Get the context - could be dict or RequestContext object
-            context = adhoc_attrs.get('context')
+            context = adhoc_attrs.get('context', {})
 
+            original_resources = []
             # Handle both dict and RequestContext object types
-            original_resources = None
-            if isinstance(context, dict):
-                original_resources = context.get('original_resources', [])
-            elif hasattr(context, 'original_resources'):
+            if hasattr(context, 'original_resources'):
                 original_resources = context.original_resources
+            else:
+                original_resources = context.get('original_resources', [])
 
             # If we found original_resources and it's a list, get project_id
             if original_resources and isinstance(original_resources, list):

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -520,13 +520,25 @@ class OpenStackAuditMiddleware(object):
         if not action:
             return None
 
+        # Try to get project_id from request headers
         project_id = request.environ.get('HTTP_X_PROJECT_ID')
-        # If project_id is undefined, look for another variable. This is
-        # added specific to catching delete events from Neutron
+
+        # If no project_id found, try to get it from the request context
         if project_id is None:
+            # Get the adhoc attributes from the request environment
             adhoc_attrs = request.environ.get('webob.adhoc_attrs', {})
-            context = adhoc_attrs.get('context', {})
-            original_resources = context.get('original_resources', [])
+
+            # Get the context - could be dict or RequestContext object
+            context = adhoc_attrs.get('context')
+
+            # Handle both dict and RequestContext object types
+            original_resources = None
+            if isinstance(context, dict):
+                original_resources = context.get('original_resources', [])
+            elif hasattr(context, 'original_resources'):
+                original_resources = context.original_resources
+
+            # If we found original_resources and it's a list, get project_id
             if original_resources and isinstance(original_resources, list):
                 first_resource = original_resources[0]
                 if isinstance(first_resource, dict):


### PR DESCRIPTION
The audit middleware was assuming all contexts were dictionary-like objects,
causing AttributeError when handling Ironic requests where context is a
RequestContext object. This change adds proper type checking to safely handle
both dictionary and object-style contexts.

Error fixed:
AttributeError: 'RequestContext' object has no attribute 'get'