### PR TITLE
Remove X preceding unmapped TypeURIs

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ Usually all custom actions should be listed in the mapping because otherwise the
  
  The mapping of actions is complex: For payload-encoded actions a default-mapping will be applied which determines the primary action (e.g. `update`) from the HTTP method and adds the action name from the payload (e.g. `update/myaction`).
 
- For path-encoded actions you can reach a similar behaviour with a generic rule of the form `"<method>:*": "<action>"` (e.g. `"POST:*": "read"`). You can refer to the actual action name in the path via `*` (e.g. `"POST:*": "update/*"`). If the right side of the rule is `null, the `entire request will be suppressed, so that no event is emitted (e.g. `"POST:*": null`).
+ For path-encoded actions you can reach a similar behaviour with a generic rule of the form `"<method>:*": "<action>"` (e.g. `"POST:*": "read"`). You can refer to the actual action name in the path via `*` (e.g. `"POST:*": "update/*"`). If the right side of the rule is `null`, the entire request will be suppressed, so that no event is emitted (e.g. `"POST:*": null`).
 
  If there is no rule matching the path suffix, it will be interpreted as a _key_, not as an action. That means that the action will be determined from the HTTP method only and an attachment with the name `key` and the name of the key as `content` will be added to the event.
 
@@ -269,9 +269,9 @@ In our example this looks like this:
 Undeclared Resources
 --------------------
 
-Resources that are not declared in the mapping file will be reported as _unknown_ in the operational logs.  Still the middleware tries to create events for them based on heuristics. They can be recognized by the `X` prefix in the resource name.
+Resources that are not declared in the mapping file will be reported as _unknown_ in the operational logs.  Still the middleware tries to create events for them based on heuristics.
 
-When those X-resources show up, the mapping file should be extended with an appropriate resource definition. The reason is that the heuristics to discover and map undeclared resources are not covering all kinds of requests. There are ambiguities. 
+When those unknown resoucre log messages show up, the mapping file should be extended with an appropriate resource definition. The reason is that the heuristics to discover and map undeclared resources are not covering all kinds of requests. There are ambiguities. 
 
 Developing Audit Middleware
 ===========================

--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -380,7 +380,6 @@ class OpenStackAuditMiddleware(object):
         res_name = token.replace('_', '-')
         if res_name.startswith('os-'):
             res_name = res_name[3:]
-        res_name = 'X' + res_name
         res_dict = {'api_name': token}
         sub_res_spec, _ = self._build_res_spec(res_name,
                                                parent_type_uri,

--- a/auditmiddleware/tests/unit/test_audit_filter.py
+++ b/auditmiddleware/tests/unit/test_audit_filter.py
@@ -548,8 +548,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
     def test_post_resource_undeclared(self):
         """Test that resource paths w/o mapping are still causing events.
 
-        Those events can be spotted by the "X" prefixing the resource
-        name derived from the URL path.
+        Those events can be spotted by log messages in the api container.
         """
         rid = str(uuid.uuid4().hex)
         rname = "myname"
@@ -560,13 +559,12 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_CREATE,
-                         "compute/Xyetunknown", rid, rname)
+                         "compute/yetunknown", rid, rname)
 
     def test_put_resource_undeclared(self):
         """Test that resource paths w/o mapping are still causing events.
 
-        Those events can be spotted by the "X" prefixing the resource
-        name derived from the URL path.
+        Those events can be spotted by log messages in the api container.
         """
         rid = str(uuid.uuid4().hex)
         rid2 = str(uuid.uuid4().hex)
@@ -577,7 +575,7 @@ class AuditApiLogicTest(base.BaseAuditMiddlewareTest):
         event = self.build_event(request, response)
 
         self.check_event(request, response, event, taxonomy.ACTION_UPDATE,
-                         "compute/Xyetunknown/Xuchild", rid2)
+                         "compute/yetunknown/uchild", rid2)
 
     def test_post_action_no_response(self):
         """Test events are created for POST actions with no response payload.


### PR DESCRIPTION
This change removes the practice of prepending an 'X' character to the typeURI field in CADF events when the resource type is not explicitly defined in the audit mapping configuration.

Problem:

Currently, when the audit middleware encounters an API path segment for which no resource mapping exists, it dynamically creates a specification. As part of this process, it prepends an 'X' to the derived resource name, which results in typeURIs like service/Xresource-name.

While this 'X' was intended as an internal indicator for developers to identify endpoints needing proper mapping, it appears in the final, customer-facing audit events. This causes confusion for users as the 'X' is undocumented and has no defined meaning from their perspective.

Solution:

The middleware already logs a clear warning message (e.g., unknown resource: <token> (created on demand)) when it encounters an undefined resource type. This logging is sufficient for internal purposes (identifying missing mappings).

#112 