### PR TITLE
Don't call get on context if not a dict

### DIFF
--- a/auditmiddleware/_api.py
+++ b/auditmiddleware/_api.py
@@ -543,7 +543,7 @@ class OpenStackAuditMiddleware(object):
             original_resources = []
             if hasattr(context, 'original_resources'):
                 original_resources = context.original_resources
-            else:
+            elif isinstance(context, dict):
                 original_resources = context.get('original_resources', [])
 
             # If we found original_resources and it's a list, get project_id


### PR DESCRIPTION
With ironic we have a case where context is a RequestContext but this context object doesn't have the original_resources attribute. In this case we're proceeding into else, call get() on context, which RequestContext does not have either and run into

AttributeError: 'RequestContext' object has no attribute 'get'

To guard against this we're now only calling get() on context if it explicitly is a dict. If none can be found we just don't have any original_resources. The only case where this logic will break is if we have cases where we have a context object that doesn't have a original_resources attribute, is not a dict but SOMEHOW provides a get() method that would provide the original_resources when provided as a string argument (which I don't think is very likely).