### PR TITLE
fix: mock public DogStatsd API instead of private _report method

### DIFF
--- a/auditmiddleware/tests/unit/base.py
+++ b/auditmiddleware/tests/unit/base.py
@@ -105,19 +105,27 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
         self.username = "test user " + str(user_counter)
         user_counter += 1
 
-        patcher = mock.patch('datadog.dogstatsd.DogStatsd._report')
-        self.statsd_report_mock = patcher.start()
-        self.addCleanup(patcher.stop)
+        inc_patcher = mock.patch('datadog.dogstatsd.DogStatsd.increment')
+        self.statsd_increment_mock = inc_patcher.start()
+        self.addCleanup(inc_patcher.stop)
+
+        gauge_patcher = mock.patch('datadog.dogstatsd.DogStatsd.gauge')
+        self.statsd_gauge_mock = gauge_patcher.start()
+        self.addCleanup(gauge_patcher.stop)
 
     def assert_statsd_counter(self, metric, value, tags=None):
-        """Assert that a statsd counter metric has a certain value.
+        """Assert that a statsd increment was called for a metric.
 
         Parameters:
             metric: name of the metric
-            value: expected value of said metric
+            value: kept for call-site compatibility (not asserted, since
+                   increment() uses a default value internally)
             tags: tags associated with the metric (dimensions)
         """
-        self.statsd_report_mock.assert_any_call(metric, 'c', value, tags, None)
+        if tags is not None:
+            self.statsd_increment_mock.assert_any_call(metric, tags=tags)
+        else:
+            self.statsd_increment_mock.assert_any_call(metric)
 
     def assert_statsd_gauge(self, metric, value, tags=None):
         """Assert that a statsd gauge metric has a certain value.
@@ -127,7 +135,10 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
             value: expected value of said metric
             tags: tags associated with the metric (dimensions)
         """
-        self.statsd_report_mock.assert_any_call(metric, 'g', value, tags, None)
+        if tags is not None:
+            self.statsd_gauge_mock.assert_any_call(metric, value, tags=tags)
+        else:
+            self.statsd_gauge_mock.assert_any_call(metric, value)
 
     def create_middleware(self, cb, **kwargs):
         """Implement abstract method from base class."""
@@ -211,7 +222,8 @@ class BaseAuditMiddlewareTest(utils.MiddlewareTestCase):
                                            tags=_make_tags(e))
             # will not check for operational metrics
         else:
-            self.statsd_report_mock.assert_not_called()
+            self.statsd_increment_mock.assert_not_called()
+            self.statsd_gauge_mock.assert_not_called()
 
         return [e.as_dict() for e in events]
 

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -2,7 +2,7 @@
 # of appearance. Changing the order has an impact on the overall integration
 # process, which may cause wedges in the gate later.
 
-datadog==0.51.0 # 0.31.0 causing test errors
+datadog==0.52.1 # 0.31.0 causing test errors
 hacking>=8.0.0,<8.1.0 # Apache-2.0 # hacking==6.0.1 relies on py3.8 # Apache-2.0
 flake8-docstrings~=1.7.0 # MIT
 


### PR DESCRIPTION
## Summary
- Replaces mocking of private `DogStatsd._report()` with public `increment()` and `gauge()` methods
- Bumps `datadog` from 0.51.0 to 0.52.1 in test-requirements.txt
- Fixes 57/74 test failures caused by `_report()` signature change in datadog 0.52.x

## Context
PR #121 (Renovate: datadog 0.51.0 → 0.52.1) fails because the internal `_report()` method
gained new kwargs (`sampling`, `cardinality`) in 0.52.x. Rather than patching the assertions
to match the new internal signature, this PR mocks the public API so tests are resilient to
future internal refactors.

## Test plan
- [x] All 74 unit tests pass (stestr)
- [x] flake8 clean
- [x] bandit clean
- [ ] CI passes on this branch

## Notes
- The `value` parameter in `assert_statsd_counter()` is no longer asserted because the
  production code uses `increment()`'s default value. This is documented in the docstring.
- Once this merges, PR #121 can be closed as superseded.