### PR TITLE
chore: expand CODEOWNERS with observability team approvers

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,5 @@
 # @notque = lead developer
+# @notandy = timezone help
+# @Kuckkuck @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo = observability team
 
-* @notque
+* @notque @notandy @Kuckkuck @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo


### PR DESCRIPTION
## Summary
- Adds observability team and timezone-help approver to CODEOWNERS
- Enables PR approvals from team members beyond repo admins

## Reviewers added
- @notque (lead developer, existing)
- @notandy (timezone help)
- @Kuckkuck @viennaa @richardtief @olandr @joluc @trouaux @ibakshay @ashifnihalb @timojohlo (observability team)

## Context
The repo's branch protection requires 1 approving review to merge.
Previously only @notque was listed as a code owner, creating a bottleneck.
This unblocks PR #130 (statsd mock fix) and future PRs.