### PR TITLE
fix: pin constraints to sapcc/requirements stable/2025.2-m3

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ setenv = VIRTUAL_ENV={envdir}
          OS_STDOUT_NOCAPTURE=False
          OS_STDERR_NOCAPTURE=False
 deps =
-    -c{env:UPPER_CONSTRAINTS_FILE:https://git.openstack.org/cgit/openstack/requirements/plain/upper-constraints.txt}
+    -c{env:TOX_CONSTRAINTS_FILE:https://raw.githubusercontent.com/sapcc/requirements/stable/2025.2-m3/upper-constraints.txt}
     -r{toxinidir}/requirements.txt
     -r{toxinidir}/test-requirements.txt
 commands = stestr run {posargs}


### PR DESCRIPTION
## Summary
- Pin upper-constraints to `sapcc/requirements/stable/2025.2-m3` instead of upstream `openstack/requirements` master, which pins unreleased packages (e.g. `keystoneauth1===5.14.0`) and causes install failures
- Rename env var from `UPPER_CONSTRAINTS_FILE` to `TOX_CONSTRAINTS_FILE` to match the convention used by all other SAP CC OpenStack services

## Context
The previous default URL (`git.openstack.org`) was decommissioned in 2019 and redirects via 302. The `opendev.org` master branch pins packages that haven't been released to PyPI yet. Using `sapcc/requirements` stable releases (the same constraints consumed by nova, neutron, keystone, ironic, glance, etc.) ensures reproducible installs.

## Test plan
- [x] `tox -e py3` — 76 tests pass
- [x] `tox -e pep8` — flake8 + bandit clean