### PR TITLE
Neutron vpnaas ignore ipsec site connection psk

### DIFF
--- a/etc/neutron_audit_map.yaml
+++ b/etc/neutron_audit_map.yaml
@@ -165,15 +165,3 @@ resources:
       ipsec-site-connections:
       vpnservices:
         type_uri: network/vpn/vpn-services
-    singleton: true
-    children:
-      endpoint-groups:
-      ikepolicies:
-        type_uri: network/vpn/ike-policies
-        el_type_uri: network/vpn/ike-policy
-      ipsecpolicies:
-        type_uri: network/vpn/ipsec-policies
-        el_type_uri: network/vpn/ipsec-policy
-      ipsec-site-connections:
-      vpnservices:
-        type_uri: network/vpn/vpn-services

--- a/etc/neutron_audit_map.yaml
+++ b/etc/neutron_audit_map.yaml
@@ -163,5 +163,8 @@ resources:
         type_uri: network/vpn/ipsec-policies
         el_type_uri: network/vpn/ipsec-policy
       ipsec-site-connections:
+        payloads:
+          exclude:
+            - psk
       vpnservices:
         type_uri: network/vpn/vpn-services


### PR DESCRIPTION
Redact VPNaaS ipsec site connection being captured by the audit log.